### PR TITLE
Use sys.executable for helper runner

### DIFF
--- a/helpers/run.py
+++ b/helpers/run.py
@@ -1,7 +1,7 @@
 """Helper command dispatcher."""
 
 import argparse
-import shlex
+import sys
 
 from .utils import run_command
 
@@ -18,7 +18,7 @@ def main() -> None:
     parser.add_argument("command", choices=COMMANDS.keys())
     args, unknown = parser.parse_known_args()
 
-    cmd = shlex.split(f"python {COMMANDS[args.command]}") + unknown
+    cmd = [sys.executable, COMMANDS[args.command], *unknown]
     run_command(cmd)
 
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -5,16 +5,25 @@ from __future__ import annotations
 import logging
 import shlex
 import subprocess
+import sys
 from typing import Sequence
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
-def run_command(cmd: str | Sequence[str], *, check: bool = True, **kwargs) -> subprocess.CompletedProcess:
+
+def run_command(
+    cmd: str | Sequence[str], *, check: bool = True, **kwargs
+) -> subprocess.CompletedProcess:
     """Run a command and log it."""
     if isinstance(cmd, str):
         args = shlex.split(cmd)
     else:
         args = list(cmd)
-    logger.info("$ %s", " ".join(shlex.quote(a) for a in args))
+
+    log_args = args.copy()
+    if log_args and log_args[0] == sys.executable:
+        log_args[0] = "python"
+
+    logger.info("$ %s", " ".join(shlex.quote(a) for a in log_args))
     return subprocess.run(args, check=check, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from helpers.utils import run_command
+
+
+def test_run_command_logs_python(caplog):
+    caplog.set_level("INFO")
+    result = run_command(
+        [sys.executable, "-c", 'print("ok")'], capture_output=True, text=True
+    )
+    assert result.stdout.strip() == "ok"
+    assert caplog.records
+    assert caplog.records[0].message.startswith("$ python")


### PR DESCRIPTION
## Summary
- run helpers using the current Python interpreter
- show simpler log messages when running helper commands
- test run_command logging

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684202374bd8832880565922195866fb