### PR TITLE
Add script entry to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,67 @@
+[project]
+name = "py-project-tmpl"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = []
+description = "A Python Project Template"
+readme = "README.md"
+license = "MIT"
+
+[project.scripts]
+py-project-tmpl = "py_project_tmpl.cli:main"
+
+[dependency-groups]
+build = [
+    "build>=1.2.2.post1",
+]
+dev = [
+    "mcp[cli]>=1.9.2",
+    "mypy>=1.15.0",
+    "pre-commit>=4.2.0",
+    "pytest>=8.3.5",
+    "pytest-cov>=6.1.1",
+    "pytest-mock>=3.14.1",
+    "ruff>=0.11.11",
+    "types-docker>=7.1.0.20250523",
+]
+
+[tool.ruff]
+line-length = 120
+indent-width = 2
+
+[tool.ruff.format]
+indent-style = "space"
+quote-style = "double"
+
+[tool.ruff.lint]
+select = ["E", "W", "F"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+section-order = ["standard-library", "third-party", "local-folder"]
+combine-as-imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--verbose",
+    "--tb=short",
+    "--strict-markers",
+    "--disable-warnings",
+    "--cov=src/py_project_tmpl",
+    "--cov-report=term-missing",
+    "--cov-report=html:htmlcov",
+    "--cov-fail-under=85"
+]
+markers = [
+    "slow: marks tests as slow (may require Docker)",
+    "integration: marks tests as integration tests",
+    "unit: marks tests as unit tests"
+]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning"
+]


### PR DESCRIPTION
## Summary
- define CLI script entry under `[project.scripts]`

## Testing
- `ruff check .`
- `pytest -q` *(fails: unrecognized coverage args)*

------
https://chatgpt.com/codex/tasks/task_b_684202cc8b708328a1313b040e06a021