### PR TITLE
Add logging options to helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ python helpers/run.py --help         # list helper commands
 
 ## Helpers
 
+- `python helpers/build.py` – build distribution packages
 - `python helpers/test.py` – run pytest
 - `python helpers/format.py` – format via Ruff
 - `python helpers/lint.py` – lint via Ruff
 - `python helpers/docs.py [build|serve]` – MkDocs commands
+
+All helpers support `-v/--verbose` to increase logging detail and
+`--log-file` to duplicate logs to a file.
 
 The project ships with a minimal `pyproject.toml` and `.pre-commit` configuration.
 
@@ -23,5 +27,6 @@ The project ships with a minimal `pyproject.toml` and `.pre-commit` configuratio
 
 Development requirements live in optional groups:
 
-- `builder` – formatting and documentation tools
-- `tester` – pytest and related utilities
+- `build` – wheel/sdist build tools
+- `dev` – linting, testing, and formatting tools
+

--- a/helpers/bootstrap.py
+++ b/helpers/bootstrap.py
@@ -4,23 +4,26 @@ from __future__ import annotations
 
 import argparse
 
-from .utils import run_command
+from .utils import add_logging_args, configure_logging, logger, run_command
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Install dependencies and setup pre-commit."""
-    parser = argparse.ArgumentParser(prog="bootstrap")
-    parser.add_argument(
-        "--ci",
-        action="store_true",
-        help="Run in CI mode with no prompts",
-    )
-    parser.parse_args(argv)
+  """Install dependencies and setup pre-commit."""
+  parser = argparse.ArgumentParser(prog="bootstrap")
+  add_logging_args(parser)
+  parser.add_argument(
+    "--ci",
+    action="store_true",
+    help="Run in CI mode with no prompts",
+  )
+  args = parser.parse_args(argv)
 
-    run_command("uv venv", check=False)
-    run_command("uv pip install -r uv.lock", check=False)
-    run_command("pre-commit install", check=False)
+  configure_logging(args.verbose, args.log_file)
+  logger.debug("ci mode: %s", args.ci)
+  run_command("uv venv", check=False)
+  run_command("uv pip install -r uv.lock", check=False)
+  run_command("pre-commit install", check=False)
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/helpers/build.py
+++ b/helpers/build.py
@@ -1,4 +1,4 @@
-"""Lint code with Ruff."""
+"""Build distribution packages."""
 
 from __future__ import annotations
 
@@ -8,14 +8,14 @@ from .utils import add_logging_args, configure_logging, logger, run_command
 
 
 def main(argv: list[str] | None = None) -> None:
-  parser = argparse.ArgumentParser(prog="lint")
+  parser = argparse.ArgumentParser(prog="build")
   add_logging_args(parser)
-  parser.add_argument("paths", nargs=argparse.REMAINDER, help="Paths to lint")
+  parser.add_argument("extra", nargs=argparse.REMAINDER, help="Extra args for python -m build")
   args = parser.parse_args(argv)
 
   configure_logging(args.verbose, args.log_file)
-  logger.debug("paths: %s", args.paths)
-  run_command(["ruff", "check", *args.paths])
+  logger.debug("extra args: %s", args.extra)
+  run_command(["python", "-m", "build", *args.extra])
 
 
 if __name__ == "__main__":

--- a/helpers/docs.py
+++ b/helpers/docs.py
@@ -2,19 +2,27 @@
 
 import argparse
 
-from .utils import run_command
+from .utils import (
+  add_logging_args,
+  configure_logging,
+  logger,
+  run_command,
+)
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("action", choices=["build", "serve"])
-    args = parser.parse_args()
+def main(argv: list[str] | None = None) -> None:
+  parser = argparse.ArgumentParser()
+  add_logging_args(parser)
+  parser.add_argument("action", choices=["build", "serve"])
+  args = parser.parse_args(argv)
 
-    if args.action == "build":
-        run_command("mkdocs build")
-    else:
-        run_command("mkdocs serve")
+  configure_logging(args.verbose, args.log_file)
+  logger.debug("docs action: %s", args.action)
+  if args.action == "build":
+    run_command("mkdocs build")
+  else:
+    run_command("mkdocs serve")
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/helpers/format.py
+++ b/helpers/format.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import argparse
 
-from .utils import run_command
+from .utils import add_logging_args, configure_logging, logger, run_command
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog="format")
-    parser.add_argument("paths", nargs=argparse.REMAINDER, help="Paths to format")
-    args = parser.parse_args(argv)
+  parser = argparse.ArgumentParser(prog="format")
+  add_logging_args(parser)
+  parser.add_argument("paths", nargs=argparse.REMAINDER, help="Paths to format")
+  args = parser.parse_args(argv)
 
-    run_command(["ruff", "format", *args.paths])
+  configure_logging(args.verbose, args.log_file)
+  logger.debug("paths: %s", args.paths)
+  run_command(["ruff", "format", *args.paths])
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/helpers/run.py
+++ b/helpers/run.py
@@ -3,24 +3,28 @@
 import argparse
 import sys
 
-from .utils import run_command
+from .utils import add_logging_args, configure_logging, logger, run_command
 
 COMMANDS = {
-    "format": "helpers/format.py",
-    "lint": "helpers/lint.py",
-    "test": "helpers/test.py",
-    "docs": "helpers/docs.py",
+  "build": "helpers/build.py",
+  "format": "helpers/format.py",
+  "lint": "helpers/lint.py",
+  "test": "helpers/test.py",
+  "docs": "helpers/docs.py",
 }
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Run helper commands")
-    parser.add_argument("command", choices=COMMANDS.keys())
-    args, unknown = parser.parse_known_args()
+def main(argv: list[str] | None = None) -> None:
+  parser = argparse.ArgumentParser(description="Run helper commands")
+  add_logging_args(parser)
+  parser.add_argument("command", choices=COMMANDS.keys())
+  args, unknown = parser.parse_known_args(argv)
 
-    cmd = [sys.executable, COMMANDS[args.command], *unknown]
-    run_command(cmd)
+  configure_logging(args.verbose, args.log_file)
+  logger.debug("dispatching %s", args.command)
+  cmd = [sys.executable, COMMANDS[args.command], *unknown]
+  run_command(cmd)
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/helpers/test.py
+++ b/helpers/test.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import argparse
 
-from .utils import run_command
+from .utils import add_logging_args, configure_logging, logger, run_command
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog="test")
-    parser.add_argument("extra", nargs=argparse.REMAINDER, help="Extra args for pytest")
-    args = parser.parse_args(argv)
+  parser = argparse.ArgumentParser(prog="test")
+  add_logging_args(parser)
+  parser.add_argument("extra", nargs=argparse.REMAINDER, help="Extra args for pytest")
+  args = parser.parse_args(argv)
 
-    run_command(["pytest", *args.extra])
+  configure_logging(args.verbose, args.log_file)
+  logger.debug("extra args: %s", args.extra)
+  run_command(["pytest", *args.extra])
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -7,23 +7,51 @@ import shlex
 import subprocess
 import sys
 from typing import Sequence
+import argparse
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 
-def run_command(
-    cmd: str | Sequence[str], *, check: bool = True, **kwargs
-) -> subprocess.CompletedProcess:
-    """Run a command and log it."""
-    if isinstance(cmd, str):
-        args = shlex.split(cmd)
-    else:
-        args = list(cmd)
+def configure_logging(verbosity: int = 0, log_file: str | None = None) -> None:
+  """Configure basic logging for helper scripts."""
+  level = logging.WARNING - (10 * verbosity)
+  if level < logging.DEBUG:
+    level = logging.DEBUG
 
-    log_args = args.copy()
-    if log_args and log_args[0] == sys.executable:
-        log_args[0] = "python"
+  handlers: list[logging.Handler] = [logging.StreamHandler()]
+  if log_file:
+    handlers.append(logging.FileHandler(log_file))
 
-    logger.info("$ %s", " ".join(shlex.quote(a) for a in log_args))
-    return subprocess.run(args, check=check, **kwargs)
+  logging.basicConfig(
+    level=level,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=handlers,
+    force=True,
+  )
+
+
+def run_command(cmd: str | Sequence[str], *, check: bool = True, **kwargs) -> subprocess.CompletedProcess:
+  """Run a command and log it."""
+  if isinstance(cmd, str):
+    args = shlex.split(cmd)
+  else:
+    args = list(cmd)
+
+  log_args = args.copy()
+  if log_args and log_args[0] == sys.executable:
+    log_args[0] = "python"
+
+  logger.info("$ %s", " ".join(shlex.quote(a) for a in log_args))
+  return subprocess.run(args, check=check, **kwargs)
+
+
+def add_logging_args(parser: argparse.ArgumentParser) -> None:
+  """Add common logging arguments to *parser*."""
+  parser.add_argument(
+    "-v",
+    "--verbose",
+    action="count",
+    default=0,
+    help="Increase log verbosity (can be repeated)",
+  )
+  parser.add_argument("--log-file", help="Write logs to this file as well")


### PR DESCRIPTION
## Summary
- add `configure_logging` and `add_logging_args` utilities
- support `--verbose`/`--log-file` in helper scripts
- log selected info in helpers
- document logging options in README

## Testing
- `ruff format helpers/*.py`
- `ruff check helpers/*.py`
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_b_684209e9031c8328b1e27e0e47e1a41b