### PR TITLE
Document OS-specific prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ python helpers/bootstrap.py          # setup venv and hooks
 python helpers/run.py --help         # list helper commands
 ```
 
+## Prerequisites
+
+The project requires **Python&nbsp;3.13** and the
+[uv](https://github.com/astral-sh/uv) package manager. Once both are
+available on your ``PATH`` the ``bootstrap`` helper will create a virtual
+environment and install the remaining tools.
+
+### Python 3.13
+
+- **Linux** – install via your package manager or with
+  [pyenv](https://github.com/pyenv/pyenv)
+- **macOS** – ``brew install python@3.13``
+- **Windows** – download the installer from
+  [python.org](https://www.python.org/downloads/)
+
+### uv
+
+- **Linux** – ``curl -Ls https://astral.sh/uv/install.sh | sh``
+- **macOS** – ``brew install uv``
+- **Windows (PowerShell)** – ``irm https://astral.sh/uv/install.ps1 | iex``
+
 ## Helpers
 
 - `python helpers/build.py` – build distribution packages

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,1 +1,0 @@
-python helpers/bootstrap.py $args

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-python helpers/bootstrap.py "$@"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,20 @@
 # Documentation
+
+## Prerequisites
+
+Install **Python&nbsp;3.13** and the [uv](https://github.com/astral-sh/uv)
+package manager before running the bootstrap helper.
+
+### Python 3.13
+
+- **Linux** – install via your package manager or
+  [pyenv](https://github.com/pyenv/pyenv)
+- **macOS** – ``brew install python@3.13``
+- **Windows** – download the installer from
+  [python.org](https://www.python.org/downloads/)
+
+### uv
+
+- **Linux** – ``curl -Ls https://astral.sh/uv/install.sh | sh``
+- **macOS** – ``brew install uv``
+- **Windows (PowerShell)** – ``irm https://astral.sh/uv/install.ps1 | iex``


### PR DESCRIPTION
## Summary
- remove bootstrap wrappers
- document how to install Python 3.13 and uv on Linux, macOS and Windows

## Testing
- `python -m pytest -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_b_684219982958832899c03468c0d04e8f