### PR TITLE
Simplify venv path logic

### DIFF
--- a/helpers/python.py
+++ b/helpers/python.py
@@ -8,16 +8,33 @@ from pathlib import Path
 from .utils import add_logging_args, configure_logging, logger, run_command
 
 
+BASE_VENV_DIR = Path(".venv")
+
+
+def resolve_venv_path(name: str) -> Path:
+  """Return path for virtual environment *name*."""
+  return BASE_VENV_DIR if name == "default" else BASE_VENV_DIR / name
+
+
+def ensure_venv_exists(name: str) -> Path:
+  """Return path to existing virtual environment *name*, or exit."""
+  path = resolve_venv_path(name)
+  if not path.exists():
+    logger.error("Virtual environment '%s' not found", name)
+    raise SystemExit(1)
+  return path
+
+
 def install_python(args: argparse.Namespace) -> None:
   """Install Python version from .python-version file."""
   version_file = Path(".python-version")
   if not version_file.exists():
     logger.error(".python-version file not found")
     raise SystemExit(1)
-    
+
   version = version_file.read_text().strip()
   logger.debug("target version: %s", version)
-  
+
   # Check if version is already installed
   result = run_command(
     ["pyenv", "versions", "--bare"],
@@ -25,14 +42,14 @@ def install_python(args: argparse.Namespace) -> None:
     text=True,
     check=False,
   )
-  
+
   installed_versions = result.stdout.strip().split("\n") if result.stdout else []
   version_installed = version in installed_versions
-  
+
   if version_installed and not args.force:
     logger.info("Python %s is already installed", version)
     return
-    
+
   # Install the version
   logger.info("Installing Python %s...", version)
   run_command(["pyenv", "install", version] + (["--force"] if args.force else []))
@@ -41,54 +58,46 @@ def install_python(args: argparse.Namespace) -> None:
 
 def create_venv(args: argparse.Namespace) -> None:
   """Create a named virtual environment."""
-  venv_path = Path(".venv") if args.name == "default" else Path(f".venv-{args.name}")
-  
+  venv_path = resolve_venv_path(args.name)
+
   if venv_path.exists() and not args.force:
     logger.info("Virtual environment '%s' already exists", args.name)
     return
-    
+
   logger.info("Creating virtual environment '%s'...", args.name)
   cmd = ["uv", "venv", str(venv_path)]
   if args.force:
     cmd.append("--force")
-  
+
   run_command(cmd)
   logger.info("Virtual environment '%s' created at %s", args.name, venv_path)
 
 
 def install_deps(args: argparse.Namespace) -> None:
   """Install dependency group in virtual environment."""
-  venv_path = Path(".venv") if args.venv == "default" else Path(f".venv-{args.venv}")
-  
-  if not venv_path.exists():
-    logger.error("Virtual environment '%s' not found", args.venv)
-    raise SystemExit(1)
-    
+  venv_path = ensure_venv_exists(args.venv)
+
   logger.info("Installing '%s' dependencies in '%s'...", args.group, args.venv)
-  
+
   # Build command based on group
   if args.group == "base":
     cmd = ["uv", "pip", "install", "-r", "uv.lock"]
   else:
     cmd = ["uv", "pip", "install", "--group", args.group]
-    
+
   # Add virtual environment path
   cmd.extend(["--python", str(venv_path)])
-  
+
   run_command(cmd)
   logger.info("Dependencies installed successfully")
 
 
 def run_in_venv(args: argparse.Namespace) -> None:
   """Run command in virtual environment."""
-  venv_path = Path(".venv") if args.venv == "default" else Path(f".venv-{args.venv}")
-  
-  if not venv_path.exists():
-    logger.error("Virtual environment '%s' not found", args.venv)
-    raise SystemExit(1)
-    
+  venv_path = ensure_venv_exists(args.venv)
+
   logger.debug("Running in venv '%s': %s", args.venv, args.command)
-  
+
   # Use uv run with the specified venv
   cmd = ["uv", "run", "--python", str(venv_path), *args.command]
   run_command(cmd)
@@ -97,9 +106,9 @@ def run_in_venv(args: argparse.Namespace) -> None:
 def main(argv: list[str] | None = None) -> None:
   parser = argparse.ArgumentParser(prog="install_python")
   add_logging_args(parser)
-  
+
   subparsers = parser.add_subparsers(dest="action", required=True)
-  
+
   # Install Python subcommand
   install_parser = subparsers.add_parser("install", help="Install Python version")
   install_parser.add_argument(
@@ -107,7 +116,7 @@ def main(argv: list[str] | None = None) -> None:
     action="store_true",
     help="Force reinstall even if version exists",
   )
-  
+
   # Create venv subcommand
   venv_parser = subparsers.add_parser("venv", help="Create virtual environment")
   venv_parser.add_argument(
@@ -121,7 +130,7 @@ def main(argv: list[str] | None = None) -> None:
     action="store_true",
     help="Recreate if exists",
   )
-  
+
   # Install deps subcommand
   deps_parser = subparsers.add_parser("deps", help="Install dependency group")
   deps_parser.add_argument(
@@ -134,7 +143,7 @@ def main(argv: list[str] | None = None) -> None:
     default="default",
     help="Virtual environment name (default: 'default')",
   )
-  
+
   # Run command subcommand
   run_parser = subparsers.add_parser("run", help="Run command in venv")
   run_parser.add_argument(
@@ -147,10 +156,10 @@ def main(argv: list[str] | None = None) -> None:
     default="default",
     help="Virtual environment name (default: 'default')",
   )
-  
+
   args = parser.parse_args(argv)
   configure_logging(args.verbose, args.log_file)
-  
+
   # Dispatch to appropriate function
   if args.action == "install":
     install_python(args)

--- a/tests/helpers/test_python.py
+++ b/tests/helpers/test_python.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+import helpers.python as hp
+
+
+def test_resolve_venv_path_default():
+  assert hp.resolve_venv_path("default") == Path(".venv")
+
+
+def test_resolve_venv_path_named():
+  assert hp.resolve_venv_path("foo") == Path(".venv") / "foo"
+
+
+def test_ensure_venv_exists(monkeypatch, tmp_path):
+  monkeypatch.setattr(hp, "BASE_VENV_DIR", tmp_path / ".venv")
+  existing = hp.BASE_VENV_DIR / "foo"
+  existing.mkdir(parents=True)
+  assert hp.ensure_venv_exists("foo") == existing
+  with pytest.raises(SystemExit):
+    hp.ensure_venv_exists("bar")


### PR DESCRIPTION
## Summary
- centralize venv path resolution in helpers/python.py
- store named venvs inside `.venv` folder
- add tests for new helper functions

## Testing
- `ruff format helpers/python.py tests/helpers/test_python.py`
- `ruff check helpers/python.py tests/helpers/test_python.py`
- `pytest -q -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_b_68423054ff6c832892f70486da776558