### PR TITLE
Add decision & verification tracking to bootstrap

### DIFF
--- a/helpers/bootstrap/00_foundation.py
+++ b/helpers/bootstrap/00_foundation.py
@@ -159,6 +159,11 @@ def probe_environment_variables() -> dict[str, Any]:
   return result
 
 
+def verify_foundation(checks: dict[str, bool]) -> dict[str, Any]:
+  """Return whether all foundation checks passed."""
+  return {"foundation_ready": all(checks.values())}
+
+
 def probe_system_resources() -> dict[str, Any]:
   """Probe system resource availability."""
   result = {
@@ -264,6 +269,7 @@ def main() -> None:
   # Store readiness indicators as dynamic fields for compatibility
   state.foundation_ready = all(checks.values())
   state.foundation_checks = checks
+  state.record_verification("foundation", verify_foundation(checks))
 
   state.layer = 0
   state.layers.append({"layer": 0, "name": "foundation", "results": layer_results})

--- a/helpers/bootstrap/10_prereqs.py
+++ b/helpers/bootstrap/10_prereqs.py
@@ -358,6 +358,11 @@ def check_prerequisites() -> dict[str, bool]:
   return checks
 
 
+def verify_prerequisites() -> dict[str, Any]:
+  """Verify prerequisite availability."""
+  return {"checks": check_prerequisites()}
+
+
 def main() -> None:
   """Probe prerequisites layer information."""
   parser = argparse.ArgumentParser(description="Layer 1: Prerequisites Probe")
@@ -400,6 +405,7 @@ def main() -> None:
   prerequisite_checks = check_prerequisites()
   state.prerequisites_met = all(prerequisite_checks.values())
   state.prerequisite_checks = prerequisite_checks
+  state.record_verification("prerequisites", verify_prerequisites())
 
   state.layer = 1
   state.layers.append({"layer": 1, "name": "prerequisites", "results": layer_results})

--- a/helpers/bootstrap/20_tools.py
+++ b/helpers/bootstrap/20_tools.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from .state import BootstrapState
 from .platform import get_platform_handler
+from .verify import verify_tool
 from ..utils import configure_logging, run_command, check_command_exists
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,30 @@ def get_project_python_version(project_root: Path) -> str | None:
   return None
 
 
+def verify_uv() -> dict[str, Any]:
+  """Verify uv installation."""
+  return {"uv": verify_tool("uv")}
+
+
+def verify_pyenv() -> dict[str, Any]:
+  """Verify pyenv installation."""
+  return {"pyenv": verify_tool("pyenv")}
+
+
+def verify_python_version(version: str) -> dict[str, Any]:
+  """Check if *version* of Python is available."""
+  for cmd in [f"python{version}", "python3", "python"]:
+    if check_command_exists(cmd):
+      out = run_command([cmd, "--version"], check=False, capture_output=True, text=True)
+      if out.returncode == 0 and version in out.stdout:
+        return {"python": {"version": version, "available": True}}
+  if check_command_exists("pyenv"):
+    versions_result = run_command(["pyenv", "versions", "--bare"], check=False, capture_output=True, text=True)
+    if versions_result.returncode == 0 and version in versions_result.stdout.splitlines():
+      return {"python": {"version": version, "available": True}}
+  return {"python": {"version": version, "available": False}}
+
+
 def main() -> None:
   """Install and configure managed tools."""
   parser = argparse.ArgumentParser(description="Layer 2: Managed Tools")
@@ -116,27 +141,43 @@ def main() -> None:
 
   layer_results: dict[str, Any] = {}
 
-  # Install uv
   if not args.skip_uv:
-    uv_res = install_uv(state.platform)
-    layer_results.update(uv_res)
-    if uv_res.get("uv", {}).get("installed"):
-      state.installed_tools["uv"] = uv_res["uv"]
+    if verify_uv()["uv"]["installed"]:
+      state.record_decision("uv", "reuse")
+    else:
+      uv_res = install_uv(state.platform)
+      layer_results.update(uv_res)
+      state.record_decision("uv", "install")
+    uv_verify = verify_uv()
+    state.record_verification("uv", uv_verify)
+    if uv_verify["uv"]["installed"]:
+      state.installed_tools["uv"] = uv_verify["uv"]
 
   # Install pyenv (optional, not critical)
   if not args.skip_pyenv:
-    pyenv_res = install_pyenv(state.platform)
-    layer_results.update(pyenv_res)
-    if pyenv_res.get("pyenv", {}).get("installed"):
-      state.installed_tools["pyenv"] = pyenv_res["pyenv"]
+    if verify_pyenv()["pyenv"]["installed"]:
+      state.record_decision("pyenv", "reuse")
+    else:
+      pyenv_res = install_pyenv(state.platform)
+      layer_results.update(pyenv_res)
+      state.record_decision("pyenv", "install")
+    pyenv_verify = verify_pyenv()
+    state.record_verification("pyenv", pyenv_verify)
+    if pyenv_verify["pyenv"]["installed"]:
+      state.installed_tools["pyenv"] = pyenv_verify["pyenv"]
 
   # Ensure Python version
   if not args.skip_python:
     python_version = args.python or get_project_python_version(project_root) or "3.13"
-    py_res = ensure_python_version(python_version)
-    layer_results.update(py_res)
-    state.installed_tools["python"] = py_res.get("python", {})
-    state.record_decision("python", python_version)
+    if verify_python_version(python_version)["python"]["available"]:
+      state.record_decision("python", "reuse")
+    else:
+      py_res = ensure_python_version(python_version)
+      layer_results.update(py_res)
+      state.record_decision("python", "install")
+    py_verify = verify_python_version(python_version)
+    state.record_verification("python", py_verify)
+    state.installed_tools["python"] = {"version": python_version, "installed": py_verify["python"]["available"]}
 
   if not args.skip_uv and not state.installed_tools.get("uv", {}).get("installed"):
     logger.error("Critical: uv installation failed")

--- a/helpers/bootstrap/30_proj.py
+++ b/helpers/bootstrap/30_proj.py
@@ -13,7 +13,7 @@ import shutil
 from typing import Any
 
 from .state import BootstrapState
-from .verify import verify_venv
+from .verify import verify_venv, verify_tool
 from ..tools import python as pytools
 from ..utils import configure_logging, run_command
 
@@ -134,6 +134,19 @@ def verify_project_structure(project_root: Path) -> dict[str, Any]:
   return result
 
 
+def verify_dev_tools(venv_path: Path) -> dict[str, Any]:
+  """Verify that development tools are available."""
+  return {
+    "dev_tools": {"pre_commit": verify_tool("pre-commit")["installed"], "mkdocs": verify_tool("mkdocs")["installed"]}
+  }
+
+
+def verify_dependencies_accessible(venv_path: Path) -> dict[str, Any]:
+  """Check that pip is functional inside the venv."""
+  res = run_command(["uv", "pip", "list", "--python", str(venv_path)], check=False)
+  return {"dependencies": {"accessible": res.returncode == 0}}
+
+
 def main() -> None:
   """Setup project environment."""
   parser = argparse.ArgumentParser(description="Layer 3: Project Environment")
@@ -170,21 +183,31 @@ def main() -> None:
 
   layer_results.update(verify_project_structure(project_root))
 
-  # Create virtual environment
-  venv_result = create_virtual_environment(project_root, python_version)
-  layer_results.update(venv_result)
+  venv_path = project_root / ".venv"
+  initial_venv = verify_venv(venv_path)
+  state.record_verification("venv", initial_venv)
+  if initial_venv["valid"]:
+    state.record_decision("venv", "reuse")
+  else:
+    venv_result = create_virtual_environment(project_root, python_version)
+    layer_results.update(venv_result)
+    state.record_decision("venv", "create" if venv_result["venv"]["created"] else "fail")
+    state.record_verification("venv", verify_venv(venv_path))
 
-  # Proceed with dependencies only if venv was created
-  if venv_result["venv"]["created"]:
-    venv_path = Path(venv_result["venv"]["path"])
-
+  if (venv_path / "bin/python").exists():
     # Install dependencies
     if not args.skip_deps:
       layer_results.update(install_dependencies(project_root, venv_path))
+      dep_verify = verify_dependencies_accessible(venv_path)
+      state.record_verification("dependencies", dep_verify)
 
     # Install development tools
     if not args.skip_tools:
       layer_results.update(install_development_tools(venv_path))
+      state.record_decision("dev_tools", "install")
+      state.record_verification("dev_tools", verify_dev_tools(venv_path))
+    else:
+      state.record_decision("dev_tools", "skip")
 
   # Pass through previous layer data
   state.layer = 3

--- a/helpers/bootstrap/40_dx.py
+++ b/helpers/bootstrap/40_dx.py
@@ -41,6 +41,12 @@ def install_pre_commit_hooks(project_root: Path) -> dict[str, Any]:
   return result
 
 
+def verify_pre_commit_hooks(project_root: Path) -> dict[str, Any]:
+  """Check if pre-commit hooks are installed."""
+  hooks_dir = project_root / ".git" / "hooks" / "pre-commit"
+  return {"pre_commit": {"installed": hooks_dir.exists()}}
+
+
 def configure_ide_settings(project_root: Path) -> dict[str, Any]:
   """Create IDE configuration files if not present."""
   result = {"ide_settings": {"vscode": False, "pycharm": False}}
@@ -68,6 +74,13 @@ def configure_ide_settings(project_root: Path) -> dict[str, Any]:
     logger.info("Created PyCharm directory structure")
 
   return result
+
+
+def verify_ide_settings(project_root: Path) -> dict[str, Any]:
+  """Verify presence of IDE configuration directories."""
+  vscode_dir = project_root / ".vscode" / "settings.json"
+  idea_dir = project_root / ".idea"
+  return {"ide_settings": {"vscode": vscode_dir.exists(), "pycharm": idea_dir.exists()}}
 
 
 def verify_helper_scripts(project_root: Path) -> dict[str, Any]:
@@ -127,16 +140,25 @@ def main() -> None:
   # Layer 4 operations
   layer_results: dict[str, Any] = {}
 
-  # Install pre-commit hooks
   if not args.skip_pre_commit:
-    layer_results.update(install_pre_commit_hooks(project_root))
+    pre_res = install_pre_commit_hooks(project_root)
+    state.record_decision("pre_commit", "install" if pre_res["pre_commit"]["installed"] else "skip")
+    layer_results.update(pre_res)
+    verify_res = verify_pre_commit_hooks(project_root)
+    state.record_verification("pre_commit", verify_res)
+    layer_results.update(verify_res)
 
-  # Configure IDE settings
   if not args.skip_ide:
-    layer_results.update(configure_ide_settings(project_root))
+    ide_res = configure_ide_settings(project_root)
+    state.record_decision("ide_settings", "configure")
+    layer_results.update(ide_res)
+    verify_res = verify_ide_settings(project_root)
+    state.record_verification("ide_settings", verify_res)
+    layer_results.update(verify_res)
 
-  # Verify helper scripts
-  layer_results.update(verify_helper_scripts(project_root))
+  verify_helpers = verify_helper_scripts(project_root)
+  state.record_verification("helpers", verify_helpers)
+  layer_results.update(verify_helpers)
 
   # Pass through previous layer data
   state.layer = 4

--- a/helpers/bootstrap/state.py
+++ b/helpers/bootstrap/state.py
@@ -28,6 +28,7 @@ class BootstrapState:
   warnings: List[str] = field(default_factory=list)
   errors: List[str] = field(default_factory=list)
   decisions: Dict[str, str] = field(default_factory=dict)
+  verifications: Dict[str, Any] = field(default_factory=dict)
 
   @classmethod
   def from_dict(cls, data: Dict[str, Any]) -> "BootstrapState":
@@ -46,3 +47,8 @@ class BootstrapState:
     """Record an installation or configuration decision."""
     self.decisions[component] = decision
     logger.debug("Decision recorded: %s -> %s", component, decision)
+
+  def record_verification(self, component: str, result: Dict[str, Any]) -> None:
+    """Store verification *result* for *component*."""
+    self.verifications[component] = result
+    logger.debug("Verification recorded: %s -> %s", component, result)

--- a/helpers/build.py
+++ b/helpers/build.py
@@ -14,7 +14,7 @@ def main(argv: list[str] | None = None) -> None:
   args = parser.parse_args(argv)
 
   configure_logging(args.verbose, args.log_file)
-  
+
   with setup_working_directory(args):
     logger.debug("extra args: %s", args.extra)
     run_command(["uv", "build", *args.extra])

--- a/tests/helpers/bootstrap/test_verify.py
+++ b/tests/helpers/bootstrap/test_verify.py
@@ -1,4 +1,7 @@
 from helpers.bootstrap.verify import verify_tool, verify_venv
+import importlib
+
+verify_pre_commit_hooks = importlib.import_module("helpers.bootstrap.40_dx").verify_pre_commit_hooks
 
 
 def test_verify_tool_python():
@@ -30,3 +33,11 @@ def test_verify_venv_corrupt(tmp_path):
   res = verify_venv(venv_path)
   assert not res["valid"]
   assert res["corrupt"]
+
+
+def test_verify_pre_commit_hooks(tmp_path):
+  hooks = tmp_path / ".git" / "hooks"
+  hooks.mkdir(parents=True)
+  (hooks / "pre-commit").write_text("echo")
+  res = verify_pre_commit_hooks(tmp_path)
+  assert res["pre_commit"]["installed"]

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -28,3 +28,9 @@ def test_record_decision():
   state = BootstrapState(project_root="/tmp")
   state.record_decision("python", "use_existing")
   assert state.decisions["python"] == "use_existing"
+
+
+def test_record_verification():
+  state = BootstrapState(project_root="/tmp")
+  state.record_verification("python", {"installed": True})
+  assert state.verifications["python"]["installed"]


### PR DESCRIPTION
## Summary
- track verification results in `BootstrapState`
- update layer scripts to record decisions and verification results
- provide verify functions for layers
- test new state behaviour and verification helpers

## Testing
- `ruff check`
- `pytest -q -o addopts='' -p no:pytest_cov`

------
https://chatgpt.com/codex/tasks/task_b_684338627e688328bf9e2e88ce93298c