### PR TITLE
Fix bootstrap module imports

### DIFF
--- a/helpers/bootstrap/00_foundation.py
+++ b/helpers/bootstrap/00_foundation.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from .state import BootstrapState
-from ..utils import configure_logging
+from helpers.utils import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/helpers/bootstrap/20_tools.py
+++ b/helpers/bootstrap/20_tools.py
@@ -13,7 +13,7 @@ from typing import Any
 from .state import BootstrapState
 from .platform import get_platform_handler
 from .verify import verify_tool
-from ..utils import configure_logging, run_command, check_command_exists
+from helpers.utils import configure_logging, run_command, check_command_exists
 
 logger = logging.getLogger(__name__)
 

--- a/helpers/bootstrap/30_proj.py
+++ b/helpers/bootstrap/30_proj.py
@@ -14,8 +14,8 @@ from typing import Any
 
 from .state import BootstrapState
 from .verify import verify_venv, verify_tool
-from ..tools import python as pytools
-from ..utils import configure_logging, run_command
+from helpers.tools import python as pytools
+from helpers.utils import configure_logging, run_command
 
 logger = logging.getLogger(__name__)
 

--- a/helpers/bootstrap/40_dx.py
+++ b/helpers/bootstrap/40_dx.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .state import BootstrapState
-from ..utils import configure_logging, run_command
+from helpers.utils import configure_logging, run_command
 
 logger = logging.getLogger(__name__)
 

--- a/helpers/bootstrap/platform.py
+++ b/helpers/bootstrap/platform.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .verify import verify_tool
-from ..utils import run_command, check_command_exists
+from helpers.utils import run_command, check_command_exists
 
 logger = logging.getLogger(__name__)
 

--- a/helpers/bootstrap/verify.py
+++ b/helpers/bootstrap/verify.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from ..utils import run_command
+from helpers.utils import run_command
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- use absolute helper imports inside the bootstrap package

## Testing
- `pytest -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_b_6845de4c9fec8328a60ac02300b51f54