### PR TITLE
Fix platform serialization in bootstrap state

### DIFF
--- a/helpers/bootstrap/state.py
+++ b/helpers/bootstrap/state.py
@@ -30,14 +30,31 @@ class BootstrapState:
   decisions: Dict[str, str] = field(default_factory=dict)
   verifications: Dict[str, Any] = field(default_factory=dict)
 
+
   @classmethod
   def from_dict(cls, data: Dict[str, Any]) -> "BootstrapState":
-    """Create state from legacy dictionary representation."""
-    return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+    """Create state from dictionary representation."""
+    # Extract platform name if present
+    platform_name = data.pop("platform", None)
+
+    # Create state instance
+    state = cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    # Recreate platform object if needed
+    if platform_name and not state.platform:
+      from .platform import get_platform_handler
+
+      state.platform = get_platform_handler()
+
+    return state
 
   def to_dict(self) -> Dict[str, Any]:
     """Convert state to a JSON serialisable dictionary."""
-    return asdict(self)
+    data = asdict(self)
+    # Convert platform to string representation
+    if self.platform:
+      data["platform"] = self.platform.name
+    return data
 
   def can_proceed(self) -> bool:
     """Return ``True`` if the bootstrap process should continue."""

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -34,3 +34,15 @@ def test_record_verification():
   state = BootstrapState(project_root="/tmp")
   state.record_verification("python", {"installed": True})
   assert state.verifications["python"]["installed"]
+
+
+def test_serializes_platform():
+  state = BootstrapState(project_root="/tmp")
+  from helpers.bootstrap.platform import LinuxPlatform
+
+  state.platform = LinuxPlatform()
+  data = state.to_dict()
+  assert data["platform"] == "linux"
+  loaded = BootstrapState.from_dict(data)
+  assert loaded.platform is not None
+  assert loaded.platform.name == "linux"


### PR DESCRIPTION
## Summary
- correctly serialize platform name in `BootstrapState.to_dict`
- restore platform object when loading via `BootstrapState.from_dict`
- cover new platform behaviour in `test_state`

## Testing
- `pytest -q -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_b_6845df350b0c8328a7dd1b46dfcb2e96