### PR TITLE
Refactor bootstrap layers into callable modules

### DIFF
--- a/helpers/bootstrap/00_foundation.py
+++ b/helpers/bootstrap/00_foundation.py
@@ -220,6 +220,36 @@ def probe_system_resources() -> dict[str, Any]:
   return result
 
 
+def run(state: BootstrapState, *, skip_network: bool = False) -> BootstrapState:
+  """Execute the foundation layer."""
+
+  layer_results = {
+    "os": probe_os_info(),
+    "filesystem": probe_filesystem(),
+    "environment": probe_environment_variables(),
+    "resources": probe_system_resources(),
+  }
+
+  if not skip_network:
+    layer_results["network"] = probe_network_connectivity()
+
+  checks = {
+    "os_supported": layer_results["os"]["system"] in ["Linux", "Darwin", "Windows"],
+    "disk_space_ok": (layer_results["filesystem"]["disk_space_mb"] or 0) >= 500,
+    "can_write": layer_results["filesystem"]["cwd_writable"],
+    "network_ok": not skip_network and layer_results.get("network", {}).get("https_connectivity", False),
+  }
+
+  state.foundation_ready = all(checks.values())
+  state.foundation_checks = checks
+  state.record_verification("foundation", verify_foundation(checks))
+
+  state.layer = 0
+  state.layers.append({"layer": 0, "name": "foundation", "results": layer_results})
+
+  return state
+
+
 def main() -> None:
   """Probe foundation layer information."""
   parser = argparse.ArgumentParser(description="Layer 0: Foundation Probe")
@@ -245,34 +275,7 @@ def main() -> None:
     input_state["project_root"] = str(Path.cwd())
 
   state = BootstrapState.from_dict(input_state)
-
-  # Layer 0 operations
-  layer_results = {
-    "os": probe_os_info(),
-    "filesystem": probe_filesystem(),
-    "environment": probe_environment_variables(),
-    "resources": probe_system_resources(),
-  }
-
-  # Network probe (can be slow, so optional)
-  if not args.skip_network:
-    layer_results["network"] = probe_network_connectivity()
-
-  # Determine if environment is suitable for bootstrap
-  checks = {
-    "os_supported": layer_results["os"]["system"] in ["Linux", "Darwin", "Windows"],
-    "disk_space_ok": (layer_results["filesystem"]["disk_space_mb"] or 0) >= 500,
-    "can_write": layer_results["filesystem"]["cwd_writable"],
-    "network_ok": not args.skip_network and layer_results.get("network", {}).get("https_connectivity", False),
-  }
-
-  # Store readiness indicators as dynamic fields for compatibility
-  state.foundation_ready = all(checks.values())
-  state.foundation_checks = checks
-  state.record_verification("foundation", verify_foundation(checks))
-
-  state.layer = 0
-  state.layers.append({"layer": 0, "name": "foundation", "results": layer_results})
+  state = run(state, skip_network=args.skip_network)
 
   # Output state to stdout
   json.dump(state.to_dict(), sys.stdout, indent=2)
@@ -282,7 +285,7 @@ def main() -> None:
     logger.info("Foundation layer probe complete - environment suitable")
   else:
     logger.warning("Foundation layer probe complete - issues detected")
-    for check, passed in checks.items():
+    for check, passed in state.foundation_checks.items():
       if not passed:
         logger.warning(f"  Failed: {check}")
 

--- a/helpers/bootstrap/10_prereqs.py
+++ b/helpers/bootstrap/10_prereqs.py
@@ -363,6 +363,30 @@ def verify_prerequisites() -> dict[str, Any]:
   return {"checks": check_prerequisites()}
 
 
+def run(state: BootstrapState, *, quick: bool = False) -> BootstrapState:
+  """Execute the prerequisites layer."""
+
+  layer_results = {
+    "shell": probe_shell_environment(),
+    "git": probe_git_installation(),
+    "python": probe_python_installations(),
+  }
+
+  if not quick:
+    layer_results["package_managers"] = probe_package_managers()
+    layer_results["dev_tools"] = probe_development_tools()
+
+  prerequisite_checks = check_prerequisites()
+  state.prerequisites_met = all(prerequisite_checks.values())
+  state.prerequisite_checks = prerequisite_checks
+  state.record_verification("prerequisites", verify_prerequisites())
+
+  state.layer = 1
+  state.layers.append({"layer": 1, "name": "prerequisites", "results": layer_results})
+
+  return state
+
+
 def main() -> None:
   """Probe prerequisites layer information."""
   parser = argparse.ArgumentParser(description="Layer 1: Prerequisites Probe")
@@ -388,27 +412,7 @@ def main() -> None:
     input_state["project_root"] = str(Path.cwd())
 
   state = BootstrapState.from_dict(input_state)
-
-  # Layer 1 operations
-  layer_results = {
-    "shell": probe_shell_environment(),
-    "git": probe_git_installation(),
-    "python": probe_python_installations(),
-  }
-
-  # Slower probes (optional)
-  if not args.quick:
-    layer_results["package_managers"] = probe_package_managers()
-    layer_results["dev_tools"] = probe_development_tools()
-
-  # Check prerequisites
-  prerequisite_checks = check_prerequisites()
-  state.prerequisites_met = all(prerequisite_checks.values())
-  state.prerequisite_checks = prerequisite_checks
-  state.record_verification("prerequisites", verify_prerequisites())
-
-  state.layer = 1
-  state.layers.append({"layer": 1, "name": "prerequisites", "results": layer_results})
+  state = run(state, quick=args.quick)
 
   # Output state to stdout
   json.dump(state.to_dict(), sys.stdout, indent=2)
@@ -418,7 +422,7 @@ def main() -> None:
     logger.info("Prerequisites layer probe complete - all requirements met")
   else:
     logger.warning("Prerequisites layer probe complete - missing requirements")
-    for check, passed in prerequisite_checks.items():
+    for check, passed in state.prerequisite_checks.items():
       if not passed:
         logger.warning(f"  Missing: {check}")
 

--- a/helpers/bootstrap/20_tools.py
+++ b/helpers/bootstrap/20_tools.py
@@ -108,6 +108,68 @@ def verify_python_version(version: str) -> dict[str, Any]:
   return {"python": {"version": version, "available": False}}
 
 
+def run(
+  state: BootstrapState,
+  *,
+  skip_uv: bool = False,
+  skip_pyenv: bool = False,
+  skip_python: bool = False,
+  python_version: str | None = None,
+) -> BootstrapState:
+  """Execute the managed tools layer."""
+
+  if state.platform is None:
+    state.platform = get_platform_handler()
+  project_root = Path(state.project_root)
+
+  layer_results: dict[str, Any] = {}
+
+  if not skip_uv:
+    if verify_uv()["uv"]["installed"]:
+      state.record_decision("uv", "reuse")
+    else:
+      uv_res = install_uv(state.platform)
+      layer_results.update(uv_res)
+      state.record_decision("uv", "install")
+    uv_verify = verify_uv()
+    state.record_verification("uv", uv_verify)
+    if uv_verify["uv"]["installed"]:
+      state.installed_tools["uv"] = uv_verify["uv"]
+
+  if not skip_pyenv:
+    if verify_pyenv()["pyenv"]["installed"]:
+      state.record_decision("pyenv", "reuse")
+    else:
+      pyenv_res = install_pyenv(state.platform)
+      layer_results.update(pyenv_res)
+      state.record_decision("pyenv", "install")
+    pyenv_verify = verify_pyenv()
+    state.record_verification("pyenv", pyenv_verify)
+    if pyenv_verify["pyenv"]["installed"]:
+      state.installed_tools["pyenv"] = pyenv_verify["pyenv"]
+
+  if not skip_python:
+    version = python_version or get_project_python_version(project_root) or "3.13"
+    if verify_python_version(version)["python"]["available"]:
+      state.record_decision("python", "reuse")
+    else:
+      py_res = ensure_python_version(version)
+      layer_results.update(py_res)
+      state.record_decision("python", "install")
+    py_verify = verify_python_version(version)
+    state.record_verification("python", py_verify)
+    state.installed_tools["python"] = {"version": version, "installed": py_verify["python"]["available"]}
+
+  if not skip_uv and not state.installed_tools.get("uv", {}).get("installed"):
+    logger.error("Critical: uv installation failed")
+    state.errors.append("uv installation failed")
+
+  state.layer = 2
+  state.layers.append({"layer": 2, "name": "managed_tools", "results": layer_results})
+
+  return state
+
+
 def main() -> None:
   """Install and configure managed tools."""
   parser = argparse.ArgumentParser(description="Layer 2: Managed Tools")
@@ -135,56 +197,13 @@ def main() -> None:
     input_state["project_root"] = str(Path.cwd())
 
   state = BootstrapState.from_dict(input_state)
-  if state.platform is None:
-    state.platform = get_platform_handler()
-  project_root = Path(state.project_root)
-
-  layer_results: dict[str, Any] = {}
-
-  if not args.skip_uv:
-    if verify_uv()["uv"]["installed"]:
-      state.record_decision("uv", "reuse")
-    else:
-      uv_res = install_uv(state.platform)
-      layer_results.update(uv_res)
-      state.record_decision("uv", "install")
-    uv_verify = verify_uv()
-    state.record_verification("uv", uv_verify)
-    if uv_verify["uv"]["installed"]:
-      state.installed_tools["uv"] = uv_verify["uv"]
-
-  # Install pyenv (optional, not critical)
-  if not args.skip_pyenv:
-    if verify_pyenv()["pyenv"]["installed"]:
-      state.record_decision("pyenv", "reuse")
-    else:
-      pyenv_res = install_pyenv(state.platform)
-      layer_results.update(pyenv_res)
-      state.record_decision("pyenv", "install")
-    pyenv_verify = verify_pyenv()
-    state.record_verification("pyenv", pyenv_verify)
-    if pyenv_verify["pyenv"]["installed"]:
-      state.installed_tools["pyenv"] = pyenv_verify["pyenv"]
-
-  # Ensure Python version
-  if not args.skip_python:
-    python_version = args.python or get_project_python_version(project_root) or "3.13"
-    if verify_python_version(python_version)["python"]["available"]:
-      state.record_decision("python", "reuse")
-    else:
-      py_res = ensure_python_version(python_version)
-      layer_results.update(py_res)
-      state.record_decision("python", "install")
-    py_verify = verify_python_version(python_version)
-    state.record_verification("python", py_verify)
-    state.installed_tools["python"] = {"version": python_version, "installed": py_verify["python"]["available"]}
-
-  if not args.skip_uv and not state.installed_tools.get("uv", {}).get("installed"):
-    logger.error("Critical: uv installation failed")
-    state.errors.append("uv installation failed")
-
-  state.layer = 2
-  state.layers.append({"layer": 2, "name": "managed_tools", "results": layer_results})
+  state = run(
+    state,
+    skip_uv=args.skip_uv,
+    skip_pyenv=args.skip_pyenv,
+    skip_python=args.skip_python,
+    python_version=args.python,
+  )
 
   json.dump(state.to_dict(), sys.stdout, indent=2)
   print()

--- a/helpers/bootstrap/30_proj.py
+++ b/helpers/bootstrap/30_proj.py
@@ -143,6 +143,59 @@ def verify_dependencies_accessible(name: str, venv_path: Path) -> dict[str, Any]
   return {"dependencies": {name: {"accessible": res.returncode == 0}}}
 
 
+def run(
+  state: BootstrapState,
+  *,
+  python_version: str | None = None,
+  skip_deps: bool = False,
+  skip_tools: bool = False,
+) -> BootstrapState:
+  """Execute the project environment layer."""
+
+  project_root = Path(state.project_root)
+  layer_results: dict[str, Any] = {}
+
+  layer_results.update(verify_project_structure(project_root))
+
+  venv_configs = {
+    "dev": {"groups": ["base", "dev", "build", "docs"], "tools": True},
+    "test": {"groups": ["base", "dev"], "tools": False},
+    "docs": {"groups": ["base", "docs"], "tools": False},
+  }
+
+  for name, cfg in venv_configs.items():
+    target = project_root / pytools.resolve_venv_path("default" if name == "dev" else name)
+    initial = verify_venv(target)
+    state.record_verification(f"venv_{name}", initial)
+    if initial["valid"]:
+      state.record_decision(f"venv_{name}", "reuse")
+    else:
+      venv_res = create_virtual_environment(project_root, name, python_version)
+      layer_results.setdefault("venvs", {}).update(venv_res)
+      state.record_decision(f"venv_{name}", "create" if venv_res[name]["created"] else "fail")
+      state.record_verification(f"venv_{name}", verify_venv(target))
+
+    if (target / "bin/python").exists():
+      if not skip_deps:
+        dep_res = install_dependencies(project_root, name, cfg["groups"])
+        layer_results.setdefault("dependencies", {}).update(dep_res["dependencies"])
+        dep_verify = verify_dependencies_accessible(name, target)
+        state.record_verification(f"deps_{name}", dep_verify)
+
+      if cfg["tools"] and not skip_tools:
+        tools_res = install_development_tools(target)
+        layer_results.setdefault("dev_tools", {}).update(tools_res["dev_tools"])
+        state.record_decision(f"dev_tools_{name}", "install")
+        state.record_verification(f"dev_tools_{name}", verify_dev_tools(target))
+      elif cfg["tools"]:
+        state.record_decision(f"dev_tools_{name}", "skip")
+
+  state.layer = 3
+  state.layers.append({"layer": 3, "name": "project_environment", "results": layer_results})
+
+  return state
+
+
 def main() -> None:
   """Setup project environment."""
   parser = argparse.ArgumentParser(description="Layer 3: Project Environment")
@@ -168,53 +221,8 @@ def main() -> None:
     input_state["project_root"] = str(Path.cwd())
 
   state = BootstrapState.from_dict(input_state)
-  project_root = Path(state.project_root)
   python_version = args.python or state.installed_tools.get("python", {}).get("version")
-
-  if not project_root.exists():
-    logger.error("Project root does not exist: %s", project_root)
-    sys.exit(1)
-
-  layer_results: dict[str, Any] = {}
-
-  layer_results.update(verify_project_structure(project_root))
-
-  venv_configs = {
-    "dev": {"groups": ["base", "dev", "build", "docs"], "tools": True},
-    "test": {"groups": ["base", "dev"], "tools": False},
-    "docs": {"groups": ["base", "docs"], "tools": False},
-  }
-
-  for name, cfg in venv_configs.items():
-    target = project_root / pytools.resolve_venv_path("default" if name == "dev" else name)
-    initial = verify_venv(target)
-    state.record_verification(f"venv_{name}", initial)
-    if initial["valid"]:
-      state.record_decision(f"venv_{name}", "reuse")
-    else:
-      venv_res = create_virtual_environment(project_root, name, python_version)
-      layer_results.setdefault("venvs", {}).update(venv_res)
-      state.record_decision(f"venv_{name}", "create" if venv_res[name]["created"] else "fail")
-      state.record_verification(f"venv_{name}", verify_venv(target))
-
-    if (target / "bin/python").exists():
-      if not args.skip_deps:
-        dep_res = install_dependencies(project_root, name, cfg["groups"])
-        layer_results.setdefault("dependencies", {}).update(dep_res["dependencies"])
-        dep_verify = verify_dependencies_accessible(name, target)
-        state.record_verification(f"deps_{name}", dep_verify)
-
-      if cfg["tools"] and not args.skip_tools:
-        tools_res = install_development_tools(target)
-        layer_results.setdefault("dev_tools", {}).update(tools_res["dev_tools"])
-        state.record_decision(f"dev_tools_{name}", "install")
-        state.record_verification(f"dev_tools_{name}", verify_dev_tools(target))
-      elif cfg["tools"]:
-        state.record_decision(f"dev_tools_{name}", "skip")
-
-  # Pass through previous layer data
-  state.layer = 3
-  state.layers.append({"layer": 3, "name": "project_environment", "results": layer_results})
+  state = run(state, python_version=python_version, skip_deps=args.skip_deps, skip_tools=args.skip_tools)
 
   # Output state to stdout
   json.dump(state.to_dict(), sys.stdout, indent=2)

--- a/helpers/bootstrap/40_dx.py
+++ b/helpers/bootstrap/40_dx.py
@@ -115,6 +115,43 @@ def verify_helper_scripts(project_root: Path) -> dict[str, Any]:
   return result
 
 
+def run(
+  state: BootstrapState,
+  *,
+  skip_pre_commit: bool = False,
+  skip_ide: bool = False,
+) -> BootstrapState:
+  """Execute the developer experience layer."""
+
+  project_root = Path(state.project_root)
+  layer_results: dict[str, Any] = {}
+
+  if not skip_pre_commit:
+    pre_res = install_pre_commit_hooks(project_root)
+    state.record_decision("pre_commit", "install" if pre_res["pre_commit"]["installed"] else "skip")
+    layer_results.update(pre_res)
+    verify_res = verify_pre_commit_hooks(project_root)
+    state.record_verification("pre_commit", verify_res)
+    layer_results.update(verify_res)
+
+  if not skip_ide:
+    ide_res = configure_ide_settings(project_root)
+    state.record_decision("ide_settings", "configure")
+    layer_results.update(ide_res)
+    verify_res = verify_ide_settings(project_root)
+    state.record_verification("ide_settings", verify_res)
+    layer_results.update(verify_res)
+
+  verify_helpers = verify_helper_scripts(project_root)
+  state.record_verification("helpers", verify_helpers)
+  layer_results.update(verify_helpers)
+
+  state.layer = 4
+  state.layers.append({"layer": 4, "name": "developer_experience", "results": layer_results})
+
+  return state
+
+
 def main() -> None:
   """Configure developer experience components."""
   parser = argparse.ArgumentParser(description="Layer 4: Developer Experience")
@@ -140,39 +177,11 @@ def main() -> None:
     input_state["project_root"] = str(Path.cwd())
 
   state = BootstrapState.from_dict(input_state)
-
-  # Determine project root
-  project_root = Path(state.project_root)
-  if not project_root.exists():
-    logger.error("Project root does not exist: %s", project_root)
-    sys.exit(1)
-
-  # Layer 4 operations
-  layer_results: dict[str, Any] = {}
-
-  if not args.skip_pre_commit:
-    pre_res = install_pre_commit_hooks(project_root)
-    state.record_decision("pre_commit", "install" if pre_res["pre_commit"]["installed"] else "skip")
-    layer_results.update(pre_res)
-    verify_res = verify_pre_commit_hooks(project_root)
-    state.record_verification("pre_commit", verify_res)
-    layer_results.update(verify_res)
-
-  if not args.skip_ide:
-    ide_res = configure_ide_settings(project_root)
-    state.record_decision("ide_settings", "configure")
-    layer_results.update(ide_res)
-    verify_res = verify_ide_settings(project_root)
-    state.record_verification("ide_settings", verify_res)
-    layer_results.update(verify_res)
-
-  verify_helpers = verify_helper_scripts(project_root)
-  state.record_verification("helpers", verify_helpers)
-  layer_results.update(verify_helpers)
-
-  # Pass through previous layer data
-  state.layer = 4
-  state.layers.append({"layer": 4, "name": "developer_experience", "results": layer_results})
+  state = run(
+    state,
+    skip_pre_commit=args.skip_pre_commit,
+    skip_ide=args.skip_ide,
+  )
 
   # Output state to stdout
   json.dump(state.to_dict(), sys.stdout, indent=2)

--- a/helpers/bootstrap/__main__.py
+++ b/helpers/bootstrap/__main__.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import subprocess
 import sys
 from pathlib import Path
+import importlib
 
 from helpers.utils import configure_logging, find_project_root
 from . import LAYERS
@@ -18,67 +18,25 @@ from .state import BootstrapState
 logger = logging.getLogger(__name__)
 
 
-def run_layer(layer_num: int, input_state: BootstrapState, verbose: int = 0) -> BootstrapState:
-  """Execute a single bootstrap layer with JSON state piping."""
-  layer_scripts = {
-    0: "00_foundation.py",
-    1: "10_prereqs.py",
-    2: "20_tools.py",
-    3: "30_proj.py",
-    4: "40_dx.py",
+def run_layer(layer_num: int, state: BootstrapState) -> BootstrapState:
+  """Execute a single bootstrap layer."""
+
+  layer_modules = {
+    0: "helpers.bootstrap.00_foundation",
+    1: "helpers.bootstrap.10_prereqs",
+    2: "helpers.bootstrap.20_tools",
+    3: "helpers.bootstrap.30_proj",
+    4: "helpers.bootstrap.40_dx",
   }
 
-  script_name = layer_scripts.get(layer_num)
-  if not script_name:
-    input_state.errors.append(f"Unknown layer: {layer_num}")
-    return input_state
-
-  script_path = Path(__file__).parent / script_name
-  if not script_path.exists():
-    input_state.errors.append(f"Layer script not found: {script_name}")
-    return input_state
-
-  # Build command
-  cmd = [sys.executable, str(script_path)]
-  if verbose:
-    cmd.extend(["-v"] * verbose)
+  module_name = layer_modules.get(layer_num)
+  if module_name is None:
+    state.errors.append(f"Unknown layer: {layer_num}")
+    return state
 
   logger.info("Running Layer %d: %s", layer_num, LAYERS[layer_num])
-
-  # Execute layer with JSON state piped to stdin
-  try:
-    process = subprocess.Popen(
-      cmd,
-      stdin=subprocess.PIPE,
-      stdout=subprocess.PIPE,
-      stderr=None,  # Let layer logs pass through
-      text=True,
-    )
-  except OSError as e:
-    logger.error("Failed to launch layer %d: %s", layer_num, e)
-    return {"error": f"Failed to run layer {layer_num}", "exception": str(e)}
-
-  try:
-    stdout, _ = process.communicate(json.dumps(input_state.to_dict()))
-  except Exception as e:
-    logger.error("Layer %d execution failed: %s", layer_num, e)
-    error_state = input_state
-    error_state.errors.append(f"Layer {layer_num} execution error: {e}")
-    return error_state
-
-  if process.returncode != 0:
-    logger.error("Layer %d failed with exit code %d", layer_num, process.returncode)
-    error_state = input_state
-    error_state.errors.append(f"Layer {layer_num} failed (exit {process.returncode})")
-    return error_state
-
-  try:
-    return BootstrapState.from_dict(json.loads(stdout))
-  except json.JSONDecodeError as e:
-    logger.error("Failed to parse layer %d output: %s", layer_num, e)
-    error_state = input_state
-    error_state.errors.append(f"Invalid JSON from layer {layer_num}")
-    return error_state
+  module = importlib.import_module(module_name)
+  return module.run(state)
 
 
 def print_summary(state: BootstrapState) -> None:
@@ -219,7 +177,7 @@ Examples:
 
   # Execute layers
   for layer_num in layers_to_run:
-    state = run_layer(layer_num, state, args.verbose)
+    state = run_layer(layer_num, state)
 
     if not state.can_proceed():
       logger.error("Bootstrap failed at layer %d", layer_num)

--- a/helpers/bootstrap/state.py
+++ b/helpers/bootstrap/state.py
@@ -30,14 +30,31 @@ class BootstrapState:
   decisions: Dict[str, str] = field(default_factory=dict)
   verifications: Dict[str, Any] = field(default_factory=dict)
 
+
   @classmethod
   def from_dict(cls, data: Dict[str, Any]) -> "BootstrapState":
-    """Create state from legacy dictionary representation."""
-    return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+    """Create state from dictionary representation."""
+    # Extract platform name if present
+    platform_name = data.pop("platform", None)
+
+    # Create state instance
+    state = cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    # Recreate platform object if needed
+    if platform_name and not state.platform:
+      from .platform import get_platform_handler
+
+      state.platform = get_platform_handler()
+
+    return state
 
   def to_dict(self) -> Dict[str, Any]:
     """Convert state to a JSON serialisable dictionary."""
-    return asdict(self)
+    data = asdict(self)
+    # Convert platform to string representation
+    if self.platform:
+      data["platform"] = self.platform.name
+    return data
 
   def can_proceed(self) -> bool:
     """Return ``True`` if the bootstrap process should continue."""

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -34,3 +34,15 @@ def test_record_verification():
   state = BootstrapState(project_root="/tmp")
   state.record_verification("python", {"installed": True})
   assert state.verifications["python"]["installed"]
+
+
+def test_serializes_platform():
+  state = BootstrapState(project_root="/tmp")
+  from helpers.bootstrap.platform import LinuxPlatform
+
+  state.platform = LinuxPlatform()
+  data = state.to_dict()
+  assert data["platform"] == "linux"
+  loaded = BootstrapState.from_dict(data)
+  assert loaded.platform is not None
+  assert loaded.platform.name == "linux"


### PR DESCRIPTION
## Summary
- expose `run()` functions in bootstrap layer modules
- replace subprocess execution with direct function calls
- keep module CLIs for standalone usage

## Testing
- `ruff format helpers/bootstrap/00_foundation.py helpers/bootstrap/10_prereqs.py helpers/bootstrap/20_tools.py helpers/bootstrap/30_proj.py helpers/bootstrap/40_dx.py helpers/bootstrap/__main__.py`
- `ruff check helpers/bootstrap/00_foundation.py helpers/bootstrap/10_prereqs.py helpers/bootstrap/20_tools.py helpers/bootstrap/30_proj.py helpers/bootstrap/40_dx.py helpers/bootstrap/__main__.py`
- `pytest -q -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_b_6845df350b0c8328a7dd1b46dfcb2e96