### PR TITLE
Refactor helper tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ environment and install the remaining tools.
 
 ## Helpers
 
-- `python -m helpers.tools.build` – build distribution packages
-- `python -m helpers.tools.test` – run pytest
-- `python -m helpers.tools.format` – format via Ruff
-- `python -m helpers.tools.lint` – lint via Ruff
-- `python -m helpers.tools.docs [build|serve]` – MkDocs commands
+- `python -m helpers.tools build` – build distribution packages
+- `python -m helpers.tools test` – run pytest
+- `python -m helpers.tools format` – format via Ruff
+- `python -m helpers.tools lint` – lint via Ruff
+- `python -m helpers.tools docs [build|serve]` – MkDocs commands
 
 Alternatively, use the `helpers/tool` wrapper which activates the required
 virtual environment automatically:

--- a/helpers/bootstrap/00_foundation.py
+++ b/helpers/bootstrap/00_foundation.py
@@ -15,7 +15,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from .state import BootstrapState
+from helpers.bootstrap.state import BootstrapState
 from helpers.utils import configure_logging
 
 logger = logging.getLogger(__name__)

--- a/helpers/bootstrap/10_prereqs.py
+++ b/helpers/bootstrap/10_prereqs.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from .state import BootstrapState
+from helpers.bootstrap.state import BootstrapState
 
 logger = logging.getLogger(__name__)
 

--- a/helpers/bootstrap/20_tools.py
+++ b/helpers/bootstrap/20_tools.py
@@ -10,9 +10,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from .state import BootstrapState
-from .platform import get_platform_handler
-from .verify import verify_tool
+from helpers.bootstrap.state import BootstrapState
+from helpers.bootstrap.platform import get_platform_handler
+from helpers.bootstrap.verify import verify_tool
 from helpers.utils import configure_logging, run_command, check_command_exists
 
 logger = logging.getLogger(__name__)

--- a/helpers/bootstrap/30_proj.py
+++ b/helpers/bootstrap/30_proj.py
@@ -12,8 +12,8 @@ from pathlib import Path
 import shutil
 from typing import Any
 
-from .state import BootstrapState
-from .verify import verify_venv, verify_tool
+from helpers.bootstrap.state import BootstrapState
+from helpers.bootstrap.verify import verify_venv, verify_tool
 from helpers.tools import python as pytools
 from helpers.utils import configure_logging, run_command
 

--- a/helpers/bootstrap/40_dx.py
+++ b/helpers/bootstrap/40_dx.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from .state import BootstrapState
+from helpers.bootstrap.state import BootstrapState
 from helpers.utils import configure_logging, run_command
 
 logger = logging.getLogger(__name__)

--- a/helpers/bootstrap/__init__.py
+++ b/helpers/bootstrap/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from .state import BootstrapState
-from .platform import Platform, get_platform_handler
+from helpers.bootstrap.state import BootstrapState
+from helpers.bootstrap.platform import Platform, get_platform_handler
 
 __version__ = "1.0.0"
 

--- a/helpers/bootstrap/__main__.py
+++ b/helpers/bootstrap/__main__.py
@@ -11,9 +11,9 @@ from pathlib import Path
 import importlib
 
 from helpers.utils import configure_logging, find_project_root
-from . import LAYERS
-from .platform import get_platform_handler
-from .state import BootstrapState
+from helpers.bootstrap import LAYERS
+from helpers.bootstrap.platform import get_platform_handler
+from helpers.bootstrap.state import BootstrapState
 
 logger = logging.getLogger(__name__)
 

--- a/helpers/bootstrap/platform.py
+++ b/helpers/bootstrap/platform.py
@@ -8,7 +8,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Dict
 
-from .verify import verify_tool
+from helpers.bootstrap.verify import verify_tool
 from helpers.utils import run_command, check_command_exists
 
 logger = logging.getLogger(__name__)

--- a/helpers/bootstrap/state.py
+++ b/helpers/bootstrap/state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional
 
-from .platform import Platform
+from helpers.bootstrap.platform import Platform
 
 import logging
 
@@ -30,7 +30,6 @@ class BootstrapState:
   decisions: Dict[str, str] = field(default_factory=dict)
   verifications: Dict[str, Any] = field(default_factory=dict)
 
-
   @classmethod
   def from_dict(cls, data: Dict[str, Any]) -> "BootstrapState":
     """Create state from dictionary representation."""
@@ -42,7 +41,7 @@ class BootstrapState:
 
     # Recreate platform object if needed
     if platform_name and not state.platform:
-      from .platform import get_platform_handler
+      from helpers.bootstrap.platform import get_platform_handler
 
       state.platform = get_platform_handler()
 

--- a/helpers/tool
+++ b/helpers/tool
@@ -48,4 +48,4 @@ if [ -z "${VIRTUAL_ENV-}" ]; then
 fi
 
 export PYTHONPATH="$root${PYTHONPATH+:$PYTHONPATH}"
-exec python -m "helpers.tools.$tool" "$@"
+exec python -m helpers.tools "$tool" "$@"

--- a/helpers/tools/__init__.py
+++ b/helpers/tools/__init__.py
@@ -1,1 +1,46 @@
-"""Utility tool modules for development workflows."""
+"""Helper tool framework.
+
+Each tool registers a function that extends the command line interface
+by adding a subparser. The :mod:`helpers.tools.__main__` entry point
+builds the CLI by loading all modules and invoking these registration
+callbacks.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from pathlib import Path
+from typing import Callable, Dict
+import argparse
+
+SubParser = argparse._SubParsersAction[argparse.ArgumentParser]
+
+TOOL_REGISTRY: Dict[str, Callable[[SubParser], None]] = {}
+
+
+def register_tool(name: str, func: Callable[[SubParser], None]) -> None:
+  """Register *func* to extend the CLI under ``name``."""
+
+  TOOL_REGISTRY[name] = func
+
+
+def tool(name: str) -> Callable[[Callable[[SubParser], None]], Callable[[SubParser], None]]:
+  """Decorator to register *name* as a tool."""
+
+  def decorator(func: Callable[[SubParser], None]) -> Callable[[SubParser], None]:
+    register_tool(name, func)
+    return func
+
+  return decorator
+
+
+def load_tools() -> None:
+  """Import all tool modules so they can register themselves."""
+
+  pkg_dir = Path(__file__).parent
+  for module in pkgutil.iter_modules([str(pkg_dir)]):
+    if module.name in {"__init__", "__main__"}:
+      continue
+    importlib.import_module(f"{__name__}.{module.name}")
+

--- a/helpers/tools/__main__.py
+++ b/helpers/tools/__main__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+import sys
+
+import argparse
+
+from helpers.tools import TOOL_REGISTRY, load_tools
+from helpers.utils import add_common_args, configure_logging, setup_working_directory
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(prog="helpers.tool", description="Project helper tools")
+  add_common_args(parser)
+  subparsers = parser.add_subparsers(dest="tool", required=True)
+
+  load_tools()
+  for name, register in sorted(TOOL_REGISTRY.items()):
+    register(subparsers)
+
+  return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = build_parser()
+  args = parser.parse_args(argv)
+
+  configure_logging(args.verbose, getattr(args, "log_file", None))
+
+  try:
+    with setup_working_directory(args):
+      args.func(args)
+  except subprocess.CalledProcessError as exc:
+    cmd = exc.cmd if isinstance(exc.cmd, str) else " ".join(shlex.quote(a) for a in exc.cmd)
+    logger.error("Command failed with exit code %s: %s", exc.returncode, cmd)
+    return exc.returncode
+  except Exception as exc:  # noqa: BLE001
+    logger.error("Unexpected error: %s", exc)
+    return 1
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/helpers/tools/build.py
+++ b/helpers/tools/build.py
@@ -3,30 +3,22 @@
 from __future__ import annotations
 
 import argparse
+from helpers.utils import logger, run_command
+from helpers.tools import tool, SubParser
 
 VENV_WANT = "dev"
 
-from ..utils import (
-  add_common_args,
-  configure_logging,
-  logger,
-  run_command,
-  setup_working_directory,
-)
+
+def run(args: argparse.Namespace) -> None:
+  logger.debug("extra args: %s", args.extra)
+  run_command(["uv", "build", *args.extra])
 
 
-def main(argv: list[str] | None = None) -> None:
-  parser = argparse.ArgumentParser(prog="build")
-  add_common_args(parser)
+@tool("build")
+def register(subparsers: SubParser) -> None:
+  parser = subparsers.add_parser("build", help="Build distribution packages")
   parser.add_argument("extra", nargs=argparse.REMAINDER, help="Extra args for uv build")
-  args = parser.parse_args(argv)
-
-  configure_logging(args.verbose, args.log_file)
-
-  with setup_working_directory(args):
-    logger.debug("extra args: %s", args.extra)
-    run_command(["uv", "build", *args.extra])
+  parser.set_defaults(func=run)
 
 
-if __name__ == "__main__":
-  main()
+

--- a/helpers/tools/cache.py
+++ b/helpers/tools/cache.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from helpers.utils import logger
+from helpers.tools import tool, SubParser
 
 VENV_WANT = "dev"
-
-from ..utils import add_common_args, configure_logging, logger, setup_working_directory
 
 
 BASE_CACHE_DIR = Path(".cache")
@@ -37,131 +37,105 @@ def ensure_cache_exists(name: str) -> Path:
 
 def create_cache(args: argparse.Namespace) -> None:
   """Create a named cache directory with optional parent symlink."""
-  with setup_working_directory(args):
-    cache_path = resolve_cache_path(args.name)
+  cache_path = resolve_cache_path(args.name)
 
-    # Create parent symlink if requested
-    if args.symlink_parent and BASE_CACHE_DIR.exists() and not BASE_CACHE_DIR.is_symlink():
-      logger.error("Cannot create parent symlink: %s already exists", BASE_CACHE_DIR)
-      raise SystemExit(1)
+  # Create parent symlink if requested
+  if args.symlink_parent and BASE_CACHE_DIR.exists() and not BASE_CACHE_DIR.is_symlink():
+    logger.error("Cannot create parent symlink: %s already exists", BASE_CACHE_DIR)
+    raise SystemExit(1)
 
-    if args.symlink_parent and not BASE_CACHE_DIR.exists():
-      target = Path(args.symlink_parent).expanduser().resolve()
-      if not target.exists():
-        logger.info("Creating parent cache directory at %s", target)
-        target.mkdir(parents=True, mode=0o755)
+  if args.symlink_parent and not BASE_CACHE_DIR.exists():
+    target = Path(args.symlink_parent).expanduser().resolve()
+    if not target.exists():
+      logger.info("Creating parent cache directory at %s", target)
+      target.mkdir(parents=True, mode=0o755)
 
-      logger.info("Symlinking %s -> %s", BASE_CACHE_DIR, target)
-      BASE_CACHE_DIR.symlink_to(target)
+    logger.info("Symlinking %s -> %s", BASE_CACHE_DIR, target)
+    BASE_CACHE_DIR.symlink_to(target)
 
-    # Create the cache directory
-    if cache_path.exists() and not args.force:
-      logger.info("Cache directory '%s' already exists", args.name)
-      return
+  # Create the cache directory
+  if cache_path.exists() and not args.force:
+    logger.info("Cache directory '%s' already exists", args.name)
+    return
 
-    logger.info("Creating cache directory '%s'...", args.name)
-    cache_path.mkdir(parents=True, mode=0o755, exist_ok=args.force)
-    logger.info("Cache directory '%s' created at %s", args.name, cache_path)
+  logger.info("Creating cache directory '%s'...", args.name)
+  cache_path.mkdir(parents=True, mode=0o755, exist_ok=args.force)
+  logger.info("Cache directory '%s' created at %s", args.name, cache_path)
 
 
 def list_caches(args: argparse.Namespace) -> None:
   """List all cache directories."""
-  with setup_working_directory(args):
-    if not BASE_CACHE_DIR.exists():
-      logger.info("No cache directories found")
-      return
+  if not BASE_CACHE_DIR.exists():
+    logger.info("No cache directories found")
+    return
 
-    # Check if base is a symlink
-    if BASE_CACHE_DIR.is_symlink():
-      target = BASE_CACHE_DIR.resolve()
-      print(f"Cache parent: {BASE_CACHE_DIR} -> {target}")
+  # Check if base is a symlink
+  if BASE_CACHE_DIR.is_symlink():
+    target = BASE_CACHE_DIR.resolve()
+    print(f"Cache parent: {BASE_CACHE_DIR} -> {target}")
+  else:
+    print(f"Cache parent: {BASE_CACHE_DIR}")
+
+  if BASE_CACHE_DIR.is_dir():
+    caches = []
+
+    subdirs = [d for d in BASE_CACHE_DIR.iterdir() if d.is_dir()]
+    if not subdirs:
+      caches.append("default")
     else:
-      print(f"Cache parent: {BASE_CACHE_DIR}")
+      caches.extend(d.name for d in sorted(subdirs))
 
-    # List cache directories
-    if BASE_CACHE_DIR.is_dir():
-      caches = []
-
-      # Check if BASE_CACHE_DIR itself is a cache (no subdirs)
-      subdirs = [d for d in BASE_CACHE_DIR.iterdir() if d.is_dir()]
-      if not subdirs:
-        caches.append("default")
-      else:
-        # List all subdirectories as named caches
-        caches.extend(d.name for d in sorted(subdirs))
-
-      if caches:
-        print("\nAvailable caches:")
-        for cache in caches:
-          print(f"  - {cache}")
+    if caches:
+      print("\nAvailable caches:")
+      for cache in caches:
+        print(f"  - {cache}")
 
 
 def clean_cache(args: argparse.Namespace) -> None:
   """Clean cache directory contents."""
-  with setup_working_directory(args):
-    cache_path = ensure_cache_exists(args.name)
+  cache_path = ensure_cache_exists(args.name)
 
-    logger.info("Cleaning cache directory '%s'...", args.name)
+  logger.info("Cleaning cache directory '%s'...", args.name)
 
-    # Remove all contents but keep the directory
-    count = 0
-    for item in cache_path.iterdir():
-      if item.is_dir():
-        import shutil
+  count = 0
+  for item in cache_path.iterdir():
+    if item.is_dir():
+      import shutil
 
-        shutil.rmtree(item)
-      else:
-        item.unlink()
-      count += 1
+      shutil.rmtree(item)
+    else:
+      item.unlink()
+    count += 1
 
-    logger.info("Removed %d items from cache '%s'", count, args.name)
+  logger.info("Removed %d items from cache '%s'", count, args.name)
 
 
-def main(argv: list[str] | None = None) -> None:
-  """Manage cache directories."""
-  parser = argparse.ArgumentParser(prog="cache")
-  add_common_args(parser)
+def register(subparsers: SubParser) -> None:
+  parser = subparsers.add_parser("cache", help="Manage cache directories")
 
-  subparsers = parser.add_subparsers(dest="action", required=True)
+  action_parsers = parser.add_subparsers(dest="action", required=True)
 
-  # Create cache subcommand
-  create_parser = subparsers.add_parser("create", help="Create cache directory")
+  create_parser = action_parsers.add_parser("create", help="Create cache directory")
   create_parser.add_argument(
-    "name",
-    default="default",
-    nargs="?",
-    help="Cache directory name (default: 'default')",
+    "name", default="default", nargs="?", help="Cache directory name (default: 'default')"
   )
+  create_parser.add_argument("--force", action="store_true", help="Create even if exists")
   create_parser.add_argument(
-    "--force",
-    action="store_true",
-    help="Create even if exists",
+    "--symlink-parent", metavar="PATH", help="Create parent .cache as symlink to PATH"
   )
-  create_parser.add_argument(
-    "--symlink-parent",
-    metavar="PATH",
-    help="Create parent .cache as symlink to PATH",
-  )
+  create_parser.set_defaults(func=create_cache)
 
-  # List caches subcommand
-  subparsers.add_parser("list", help="List cache directories")
+  list_parser = action_parsers.add_parser("list", help="List cache directories")
+  list_parser.set_defaults(func=list_caches)
 
-  # Clean cache subcommand
-  clean_parser = subparsers.add_parser("clean", help="Clean cache contents")
+  clean_parser = action_parsers.add_parser("clean", help="Clean cache contents")
   clean_parser.add_argument(
-    "name",
-    default="default",
-    nargs="?",
-    help="Cache directory name (default: 'default')",
+    "name", default="default", nargs="?", help="Cache directory name (default: 'default')"
   )
+  clean_parser.set_defaults(func=clean_cache)
 
-  args = parser.parse_args(argv)
-  configure_logging(args.verbose, args.log_file)
 
-  # Dispatch to appropriate function
-  if args.action == "create":
-    create_cache(args)
-  elif args.action == "list":
-    list_caches(args)
-  elif args.action == "clean":
-    clean_cache(args)
+@tool("cache")
+def main(subparsers: SubParser) -> None:
+  register(subparsers)
+

--- a/helpers/tools/docs.py
+++ b/helpers/tools/docs.py
@@ -3,27 +3,23 @@
 from __future__ import annotations
 
 import argparse
+from helpers.utils import logger, run_command
+from helpers.tools import tool, SubParser
 
 VENV_WANT = "docs"
 
-from ..utils import add_common_args, configure_logging, logger, run_command, setup_working_directory
+
+def run(args: argparse.Namespace) -> None:
+  logger.debug("docs action: %s", args.action)
+  if args.action == "build":
+    run_command("mkdocs build")
+  else:
+    run_command("mkdocs serve")
 
 
-def main(argv: list[str] | None = None) -> None:
-  parser = argparse.ArgumentParser(prog="docs")
-  add_common_args(parser)
+@tool("docs")
+def register(subparsers: SubParser) -> None:
+  parser = subparsers.add_parser("docs", help="Build or serve documentation")
   parser.add_argument("action", choices=["build", "serve"])
-  args = parser.parse_args(argv)
+  parser.set_defaults(func=run)
 
-  configure_logging(args.verbose, args.log_file)
-
-  with setup_working_directory(args):
-    logger.debug("docs action: %s", args.action)
-    if args.action == "build":
-      run_command("mkdocs build")
-    else:
-      run_command("mkdocs serve")
-
-
-if __name__ == "__main__":
-  main()

--- a/helpers/tools/format.py
+++ b/helpers/tools/format.py
@@ -3,24 +3,20 @@
 from __future__ import annotations
 
 import argparse
+from helpers.utils import logger, run_command
+from helpers.tools import tool, SubParser
 
 VENV_WANT = "dev"
 
-from ..utils import add_common_args, configure_logging, logger, run_command, setup_working_directory
+
+def run(args: argparse.Namespace) -> None:
+  logger.debug("paths: %s", args.paths)
+  run_command(["ruff", "format", *args.paths])
 
 
-def main(argv: list[str] | None = None) -> None:
-  parser = argparse.ArgumentParser(prog="format")
-  add_common_args(parser)
+@tool("format")
+def register(subparsers: SubParser) -> None:
+  parser = subparsers.add_parser("format", help="Format code with Ruff")
   parser.add_argument("paths", nargs=argparse.REMAINDER, help="Paths to format")
-  args = parser.parse_args(argv)
+  parser.set_defaults(func=run)
 
-  configure_logging(args.verbose, args.log_file)
-
-  with setup_working_directory(args):
-    logger.debug("paths: %s", args.paths)
-    run_command(["ruff", "format", *args.paths])
-
-
-if __name__ == "__main__":
-  main()

--- a/helpers/tools/lint.py
+++ b/helpers/tools/lint.py
@@ -3,24 +3,20 @@
 from __future__ import annotations
 
 import argparse
+from helpers.utils import logger, run_command
+from helpers.tools import tool, SubParser
 
 VENV_WANT = "dev"
 
-from ..utils import add_common_args, configure_logging, logger, run_command, setup_working_directory
+
+def run(args: argparse.Namespace) -> None:
+  logger.debug("paths: %s", args.paths)
+  run_command(["ruff", "check", *args.paths])
 
 
-def main(argv: list[str] | None = None) -> None:
-  parser = argparse.ArgumentParser(prog="lint")
-  add_common_args(parser)
+@tool("lint")
+def register(subparsers: SubParser) -> None:
+  parser = subparsers.add_parser("lint", help="Lint code with Ruff")
   parser.add_argument("paths", nargs=argparse.REMAINDER, help="Paths to lint")
-  args = parser.parse_args(argv)
+  parser.set_defaults(func=run)
 
-  configure_logging(args.verbose, args.log_file)
-
-  with setup_working_directory(args):
-    logger.debug("paths: %s", args.paths)
-    run_command(["ruff", "check", *args.paths])
-
-
-if __name__ == "__main__":
-  main()

--- a/helpers/tools/python.py
+++ b/helpers/tools/python.py
@@ -1,14 +1,14 @@
-"""Manage Python installations and virtual environments."""
+"""Manage Python versions and virtual environments."""
 
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
 
+from helpers.utils import logger, run_command
+from helpers.tools import tool, SubParser
+
 VENV_WANT = "dev"
-
-from ..utils import add_common_args, configure_logging, logger, run_command, setup_working_directory
-
 
 BASE_VENV_DIR = Path(".venv")
 
@@ -29,210 +29,138 @@ def ensure_venv_exists(name: str) -> Path:
 
 def install_python(args: argparse.Namespace) -> None:
   """Install Python version from .python-version file."""
-  with setup_working_directory(args):
-    version_file = Path(".python-version")
-    if not version_file.exists():
-      logger.error(".python-version file not found")
-      raise SystemExit(1)
+  version_file = Path(".python-version")
+  if not version_file.exists():
+    logger.error(".python-version file not found")
+    raise SystemExit(1)
 
-    version = version_file.read_text().strip()
-    logger.debug("target version: %s", version)
+  version = version_file.read_text().strip()
+  logger.debug("target version: %s", version)
 
-    # Check if version is already installed
-    result = run_command(
-      ["pyenv", "versions", "--bare"],
-      capture_output=True,
-      text=True,
-      check=False,
-    )
+  result = run_command([
+    "pyenv",
+    "versions",
+    "--bare",
+  ], capture_output=True, text=True, check=False)
 
-    installed_versions = result.stdout.strip().split("\n") if result.stdout else []
-    version_installed = version in installed_versions
+  installed = result.stdout.strip().split("\n") if result.stdout else []
+  if version in installed and not args.force:
+    logger.info("Python %s is already installed", version)
+    return
 
-    if version_installed and not args.force:
-      logger.info("Python %s is already installed", version)
-      return
-
-    # Install the version
-    logger.info("Installing Python %s...", version)
-    run_command(["pyenv", "install", version] + (["--force"] if args.force else []))
-    logger.info("Python %s installed successfully", version)
+  logger.info("Installing Python %s...", version)
+  run_command(["pyenv", "install", version] + (["--force"] if args.force else []))
+  logger.info("Python %s installed successfully", version)
 
 
 def create_venv(args: argparse.Namespace) -> None:
   """Create a named virtual environment with optional parent symlink."""
-  with setup_working_directory(args):
-    venv_path = resolve_venv_path(args.name)
+  venv_path = resolve_venv_path(args.name)
 
-    # Create parent symlink if requested
-    if args.symlink_parent and BASE_VENV_DIR.exists() and not BASE_VENV_DIR.is_symlink():
-      logger.error("Cannot create parent symlink: %s already exists", BASE_VENV_DIR)
-      raise SystemExit(1)
+  if args.symlink_parent and BASE_VENV_DIR.exists() and not BASE_VENV_DIR.is_symlink():
+    logger.error("Cannot create parent symlink: %s already exists", BASE_VENV_DIR)
+    raise SystemExit(1)
 
-    if args.symlink_parent and not BASE_VENV_DIR.exists():
-      target = Path(args.symlink_parent).expanduser().resolve()
-      if not target.exists():
-        logger.info("Creating parent venv directory at %s", target)
-        target.mkdir(parents=True, mode=0o755)
+  if args.symlink_parent and not BASE_VENV_DIR.exists():
+    target = Path(args.symlink_parent).expanduser().resolve()
+    if not target.exists():
+      logger.info("Creating parent venv directory at %s", target)
+      target.mkdir(parents=True, mode=0o755)
 
-      logger.info("Symlinking %s -> %s", BASE_VENV_DIR, target)
-      BASE_VENV_DIR.symlink_to(target)
+    logger.info("Symlinking %s -> %s", BASE_VENV_DIR, target)
+    BASE_VENV_DIR.symlink_to(target)
 
-    if venv_path.exists() and not args.force:
-      logger.info("Virtual environment '%s' already exists", args.name)
-      return
+  if venv_path.exists() and not args.force:
+    logger.info("Virtual environment '%s' already exists", args.name)
+    return
 
-    logger.info("Creating virtual environment '%s'...", args.name)
-    cmd = ["uv", "venv", str(venv_path)]
-    if args.force:
-      cmd.append("--force")
-
-    run_command(cmd)
-    logger.info("Virtual environment '%s' created at %s", args.name, venv_path)
+  logger.info("Creating virtual environment '%s'...", args.name)
+  cmd = ["uv", "venv", str(venv_path)]
+  if args.force:
+    cmd.append("--force")
+  run_command(cmd)
+  logger.info("Virtual environment '%s' created at %s", args.name, venv_path)
 
 
 def list_venvs(args: argparse.Namespace) -> None:
   """List all virtual environments."""
-  with setup_working_directory(args):
-    if not BASE_VENV_DIR.exists():
-      logger.info("No virtual environments found")
-      return
+  if not BASE_VENV_DIR.exists():
+    logger.info("No virtual environments found")
+    return
 
-    # Check if base is a symlink
-    if BASE_VENV_DIR.is_symlink():
-      target = BASE_VENV_DIR.resolve()
-      print(f"Venv parent: {BASE_VENV_DIR} -> {target}")
+  if BASE_VENV_DIR.is_symlink():
+    target = BASE_VENV_DIR.resolve()
+    print(f"Venv parent: {BASE_VENV_DIR} -> {target}")
+  else:
+    print(f"Venv parent: {BASE_VENV_DIR}")
+
+  if BASE_VENV_DIR.is_dir():
+    venvs: list[str] = []
+    if (BASE_VENV_DIR / "pyvenv.cfg").exists():
+      venvs.append("default")
     else:
-      print(f"Venv parent: {BASE_VENV_DIR}")
+      for d in sorted(BASE_VENV_DIR.iterdir()):
+        if d.is_dir() and (d / "pyvenv.cfg").exists():
+          venvs.append(d.name)
 
-    # List virtual environments
-    if BASE_VENV_DIR.is_dir():
-      venvs = []
-
-      # Check if BASE_VENV_DIR itself is a venv (has pyvenv.cfg)
-      if (BASE_VENV_DIR / "pyvenv.cfg").exists():
-        venvs.append("default")
-      else:
-        # List all subdirectories that are venvs
-        for d in sorted(BASE_VENV_DIR.iterdir()):
-          if d.is_dir() and (d / "pyvenv.cfg").exists():
-            venvs.append(d.name)
-
-      if venvs:
-        print("\nAvailable virtual environments:")
-        for venv in venvs:
-          print(f"  - {venv}")
+    if venvs:
+      print("\nAvailable virtual environments:")
+      for venv in venvs:
+        print(f"  - {venv}")
 
 
 def install_deps(args: argparse.Namespace) -> None:
   """Install dependency group in virtual environment."""
-  with setup_working_directory(args):
-    venv_path = ensure_venv_exists(args.venv)
+  venv_path = ensure_venv_exists(args.venv)
 
-    logger.info("Installing '%s' dependencies in '%s'...", args.group, args.venv)
+  logger.info("Installing '%s' dependencies in '%s'...", args.group, args.venv)
 
-    # Build command based on group
-    if args.group == "base":
-      cmd = ["uv", "pip", "install", "-r", "uv.lock"]
-    else:
-      cmd = ["uv", "pip", "install", "--group", args.group]
+  if args.group == "base":
+    cmd = ["uv", "pip", "install", "-r", "uv.lock"]
+  else:
+    cmd = ["uv", "pip", "install", "--group", args.group]
 
-    # Add virtual environment path
-    cmd.extend(["--python", str(venv_path)])
+  cmd.extend(["--python", str(venv_path)])
 
-    run_command(cmd)
-    logger.info("Dependencies installed successfully")
+  run_command(cmd)
+  logger.info("Dependencies installed successfully")
 
 
 def run_in_venv(args: argparse.Namespace) -> None:
   """Run command in virtual environment."""
-  with setup_working_directory(args):
-    venv_path = ensure_venv_exists(args.venv)
+  venv_path = ensure_venv_exists(args.venv)
 
-    logger.debug("Running in venv '%s': %s", args.venv, args.command)
+  logger.debug("Running in venv '%s': %s", args.venv, args.command)
 
-    # Use uv run with the specified venv
-    cmd = ["uv", "run", "--python", str(venv_path), *args.command]
-    run_command(cmd)
+  cmd = ["uv", "run", "--python", str(venv_path), *args.command]
+  run_command(cmd)
 
 
-def main(argv: list[str] | None = None) -> None:
-  parser = argparse.ArgumentParser(prog="python")
-  add_common_args(parser)
+@tool("python")
+def register(subparsers: SubParser) -> None:
+  parser = subparsers.add_parser("python", help="Manage Python versions and virtualenvs")
+  actions = parser.add_subparsers(dest="action", required=True)
 
-  subparsers = parser.add_subparsers(dest="action", required=True)
+  install_parser = actions.add_parser("install", help="Install Python version")
+  install_parser.add_argument("--force", action="store_true", help="Force reinstall even if version exists")
+  install_parser.set_defaults(func=install_python)
 
-  # Install Python subcommand
-  install_parser = subparsers.add_parser("install", help="Install Python version")
-  install_parser.add_argument(
-    "--force",
-    action="store_true",
-    help="Force reinstall even if version exists",
-  )
+  venv_parser = actions.add_parser("venv", help="Create virtual environment")
+  venv_parser.add_argument("name", default="default", nargs="?", help="Virtual environment name (default: 'default')")
+  venv_parser.add_argument("--force", action="store_true", help="Recreate if exists")
+  venv_parser.add_argument("--symlink-parent", metavar="PATH", help="Create parent .venv as symlink to PATH")
+  venv_parser.set_defaults(func=create_venv)
 
-  # Create venv subcommand
-  venv_parser = subparsers.add_parser("venv", help="Create virtual environment")
-  venv_parser.add_argument(
-    "name",
-    default="default",
-    nargs="?",
-    help="Virtual environment name (default: 'default')",
-  )
-  venv_parser.add_argument(
-    "--force",
-    action="store_true",
-    help="Recreate if exists",
-  )
-  venv_parser.add_argument(
-    "--symlink-parent",
-    metavar="PATH",
-    help="Create parent .venv as symlink to PATH",
-  )
+  list_parser = actions.add_parser("list", help="List virtual environments")
+  list_parser.set_defaults(func=list_venvs)
 
-  # List venvs subcommand
-  subparsers.add_parser("list", help="List virtual environments")
+  deps_parser = actions.add_parser("deps", help="Install dependency group")
+  deps_parser.add_argument("group", choices=["base", "dev", "build", "docs"], help="Dependency group to install")
+  deps_parser.add_argument("--venv", default="default", help="Virtual environment name (default: 'default')")
+  deps_parser.set_defaults(func=install_deps)
 
-  # Install deps subcommand
-  deps_parser = subparsers.add_parser("deps", help="Install dependency group")
-  deps_parser.add_argument(
-    "group",
-    choices=["base", "dev", "build", "docs"],
-    help="Dependency group to install",
-  )
-  deps_parser.add_argument(
-    "--venv",
-    default="default",
-    help="Virtual environment name (default: 'default')",
-  )
+  run_parser = actions.add_parser("run", help="Run command in venv")
+  run_parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to run")
+  run_parser.add_argument("--venv", default="default", help="Virtual environment name (default: 'default')")
+  run_parser.set_defaults(func=run_in_venv)
 
-  # Run command subcommand
-  run_parser = subparsers.add_parser("run", help="Run command in venv")
-  run_parser.add_argument(
-    "command",
-    nargs=argparse.REMAINDER,
-    help="Command to run",
-  )
-  run_parser.add_argument(
-    "--venv",
-    default="default",
-    help="Virtual environment name (default: 'default')",
-  )
-
-  args = parser.parse_args(argv)
-  configure_logging(args.verbose, args.log_file)
-
-  # Dispatch to appropriate function
-  if args.action == "install":
-    install_python(args)
-  elif args.action == "venv":
-    create_venv(args)
-  elif args.action == "list":
-    list_venvs(args)
-  elif args.action == "deps":
-    install_deps(args)
-  elif args.action == "run":
-    run_in_venv(args)
-
-
-if __name__ == "__main__":
-  main()

--- a/helpers/tools/test.py
+++ b/helpers/tools/test.py
@@ -3,24 +3,20 @@
 from __future__ import annotations
 
 import argparse
+from helpers.utils import logger, run_command
+from helpers.tools import tool, SubParser
 
 VENV_WANT = "test"
 
-from ..utils import add_common_args, configure_logging, logger, run_command, setup_working_directory
+
+def run(args: argparse.Namespace) -> None:
+  logger.debug("extra args: %s", args.extra)
+  run_command(["pytest", *args.extra])
 
 
-def main(argv: list[str] | None = None) -> None:
-  parser = argparse.ArgumentParser(prog="test")
-  add_common_args(parser)
+@tool("test")
+def register(subparsers: SubParser) -> None:
+  parser = subparsers.add_parser("test", help="Run tests")
   parser.add_argument("extra", nargs=argparse.REMAINDER, help="Extra args for pytest")
-  args = parser.parse_args(argv)
+  parser.set_defaults(func=run)
 
-  configure_logging(args.verbose, args.log_file)
-
-  with setup_working_directory(args):
-    logger.debug("extra args: %s", args.extra)
-    run_command(["pytest", *args.extra])
-
-
-if __name__ == "__main__":
-  main()

--- a/tests/helpers/test_tools_main.py
+++ b/tests/helpers/test_tools_main.py
@@ -1,0 +1,41 @@
+import subprocess
+import pytest
+
+from helpers.tools import __main__ as tools_main
+
+
+def test_main_unknown_tool():
+  with pytest.raises(SystemExit) as excinfo:
+    tools_main.main(["nope"])
+
+  assert excinfo.value.code == 2
+
+
+def test_main_error(monkeypatch):
+  def fail(args):
+    raise subprocess.CalledProcessError(2, ["cmd"])
+
+  def register(subparsers):
+    p = subparsers.add_parser("fake")
+    p.set_defaults(func=fail)
+
+  monkeypatch.setattr(tools_main, "load_tools", lambda: None)
+  tools_main.TOOL_REGISTRY["fake"] = register
+  code = tools_main.main(["fake"])
+  assert code == 2
+  del tools_main.TOOL_REGISTRY["fake"]
+
+
+def test_main_unexpected(monkeypatch):
+  def fail(args):
+    raise RuntimeError("boom")
+
+  def register(subparsers):
+    p = subparsers.add_parser("boom")
+    p.set_defaults(func=fail)
+
+  monkeypatch.setattr(tools_main, "load_tools", lambda: None)
+  tools_main.TOOL_REGISTRY["boom"] = register
+  code = tools_main.main(["boom"])
+  assert code == 1
+  del tools_main.TOOL_REGISTRY["boom"]


### PR DESCRIPTION
## Summary
- redesign helpers.tools CLI with subcommands
- register each tool with a decorator that adds argparse subparsers
- update individual tools to extend the shared CLI
- document new invocation pattern
- adjust tests for new argparse behaviour
- handle unexpected errors in helpers.tools main

## Testing
- `ruff check helpers/tools/__init__.py helpers/tools/__main__.py helpers/tools/build.py helpers/tools/cache.py helpers/tools/docs.py helpers/tools/format.py helpers/tools/lint.py helpers/tools/python.py helpers/tools/test.py tests/helpers/test_tools_main.py`
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_b_6845e64b695c8328b39a36eeca13df51