### PR TITLE
Update bootstrap venv groups

### DIFF
--- a/helpers/bootstrap/30_proj.py
+++ b/helpers/bootstrap/30_proj.py
@@ -158,8 +158,8 @@ def run(
   layer_results.update(verify_project_structure(project_root))
 
   venv_configs = {
-    "dev": {"groups": ["base", "dev", "build", "docs"], "tools": True},
-    "test": {"groups": ["base", "dev"], "tools": False},
+    "dev": {"groups": ["base", "dev", "test", "build", "docs"], "tools": True},
+    "test": {"groups": ["base", "test"], "tools": False},
     "docs": {"groups": ["base", "docs"], "tools": False},
   }
 

--- a/helpers/tools/python.py
+++ b/helpers/tools/python.py
@@ -155,7 +155,11 @@ def register(subparsers: SubParser) -> None:
   list_parser.set_defaults(func=list_venvs)
 
   deps_parser = actions.add_parser("deps", help="Install dependency group")
-  deps_parser.add_argument("group", choices=["base", "dev", "build", "docs"], help="Dependency group to install")
+  deps_parser.add_argument(
+    "group",
+    choices=["base", "dev", "build", "docs", "test"],
+    help="Dependency group to install",
+  )
   deps_parser.add_argument("--venv", default="default", help="Virtual environment name (default: 'default')")
   deps_parser.set_defaults(func=install_deps)
 

--- a/tests/helpers/test_python.py
+++ b/tests/helpers/test_python.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import argparse
 
 import pytest
 
@@ -20,3 +21,14 @@ def test_ensure_venv_exists(monkeypatch, tmp_path):
   assert hp.ensure_venv_exists("foo") == existing
   with pytest.raises(SystemExit):
     hp.ensure_venv_exists("bar")
+
+
+def test_deps_parser_includes_test_group() -> None:
+  parser = argparse.ArgumentParser()
+  subparsers = parser.add_subparsers(dest="tool")
+  hp.register(subparsers)
+  python_parser = subparsers.choices["python"]
+  action_subs = [a for a in python_parser._actions if isinstance(a, argparse._SubParsersAction)][0]
+  deps_parser = action_subs.choices["deps"]
+  group_action = [a for a in deps_parser._actions if getattr(a, "dest", None) == "group"][0]
+  assert "test" in group_action.choices


### PR DESCRIPTION
## Summary
- install all dependency groups when creating dev/test/docs venvs
- allow `test` group in python tool CLI
- ensure CLI exposes `test` group via unit test

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_b_68461a74c6488328bc6e47d675307062