### PR TITLE
Add cache flag for pagination

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import http.client
 import logging
 import os
 import shlex
 import subprocess
 import sys
+import urllib.parse
 from pathlib import Path
-from typing import Generator, Sequence
+from typing import Callable, Generator, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -133,3 +135,131 @@ def setup_working_directory(args: argparse.Namespace) -> contextlib.AbstractCont
     else:
       # Already at project root, no-op context manager
       return contextlib.nullcontext()
+
+
+class HttpResponse(contextlib.AbstractContextManager):
+  """Wrapper around :class:`http.client.HTTPResponse`."""
+
+  def __init__(self, raw: http.client.HTTPResponse) -> None:
+    self._raw = raw
+    self._buffer: bytes | None = None
+    self.status = raw.status
+    self.headers = dict(raw.getheaders())
+
+  def __enter__(self) -> "HttpResponse":
+    return self
+
+  def __exit__(self, exc_type, exc, tb) -> None:
+    self._raw.close()
+
+  def read(self) -> bytes:
+    """Return the entire response body."""
+    if self._buffer is None:
+      self._buffer = self._raw.read()
+    return self._buffer
+
+  def stream(self, chunk_size: int = 8192) -> Generator[bytes, None, None]:
+    """Yield response body data in ``chunk_size`` increments."""
+    if self._buffer is not None:
+      for i in range(0, len(self._buffer), chunk_size):
+        yield self._buffer[i : i + chunk_size]
+    else:
+      while True:
+        chunk = self._raw.read(chunk_size)
+        if not chunk:
+          break
+        yield chunk
+
+
+class HttpSession(contextlib.AbstractContextManager):
+  """Minimal HTTP client using :mod:`http.client`."""
+
+  def __init__(self, base_url: str, *, timeout: float | None = None) -> None:
+    parsed = urllib.parse.urlsplit(base_url)
+    if parsed.scheme not in {"http", "https"}:
+      raise ValueError(f"Unsupported scheme: {parsed.scheme!r}")
+
+    self.scheme = parsed.scheme
+    self.host = parsed.hostname or ""
+    self.port = parsed.port
+    self.base_path = parsed.path.rstrip("/")
+    self.timeout = timeout
+    self._conn: http.client.HTTPConnection | None = None
+
+  def __enter__(self) -> "HttpSession":
+    conn_cls = http.client.HTTPSConnection if self.scheme == "https" else http.client.HTTPConnection
+    self._conn = conn_cls(self.host, self.port, timeout=self.timeout)
+    return self
+
+  def __exit__(self, exc_type, exc, tb) -> None:
+    if self._conn is not None:
+      self._conn.close()
+
+  def _make_path(self, path: str) -> str:
+    if not path.startswith("/"):
+      path = f"/{path}"
+    return f"{self.base_path}{path}" if self.base_path else path
+
+  @contextlib.contextmanager
+  def request(
+    self,
+    method: str,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    body: str | bytes | None = None,
+  ) -> Generator["HttpResponse", None, None]:
+    if self._conn is None:
+      raise RuntimeError("Session not active")
+
+    target = self._make_path(path)
+    data = body.encode() if isinstance(body, str) else body
+    self._conn.request(method, target, body=data, headers=headers or {})
+    raw = self._conn.getresponse()
+    resp = HttpResponse(raw)
+    try:
+      yield resp
+    finally:
+      raw.close()
+
+  @contextlib.contextmanager
+  def get(self, path: str, *, headers: dict[str, str] | None = None) -> Generator["HttpResponse", None, None]:
+    with self.request("GET", path, headers=headers) as resp:
+      yield resp
+
+  @contextlib.contextmanager
+  def post(
+    self,
+    path: str,
+    body: str | bytes | None = None,
+    *,
+    headers: dict[str, str] | None = None,
+  ) -> Generator["HttpResponse", None, None]:
+    with self.request("POST", path, headers=headers, body=body) as resp:
+      yield resp
+
+  def paginate(
+    self,
+    path: str,
+    next_page: Callable[["HttpResponse"], str | None],
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: str | bytes | None = None,
+    cache_body: bool = True,
+  ) -> Generator["HttpResponse", None, None]:
+    """Iterate over paginated responses.
+
+    ``next_page`` should return the path for the next request or ``None``.
+    If ``cache_body`` is ``True`` the response body is read before ``next_page``
+    is invoked.
+    """
+    while True:
+      with self.request(method, path, headers=headers, body=body) as resp:
+        if cache_body:
+          resp.read()
+        next_path = next_page(resp)
+        yield resp
+      if next_path is None:
+        break
+      path = next_path

--- a/tests/helpers/test_http_session.py
+++ b/tests/helpers/test_http_session.py
@@ -1,0 +1,86 @@
+import contextlib
+import http.server
+import json
+import threading
+
+from helpers.utils import HttpSession, HttpResponse
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+  PAGES = {
+    "/p1": {"next": "/p2", "data": 1},
+    "/p2": {"next": "/p3", "data": 2},
+    "/p3": {"next": None, "data": 3},
+  }
+
+  def do_GET(self) -> None:
+    if self.path == "/ping":
+      self.send_response(200)
+      self.end_headers()
+      self.wfile.write(b"pong")
+    elif self.path in self.PAGES:
+      self.send_response(200)
+      self.end_headers()
+      payload = json.dumps(self.PAGES[self.path]).encode()
+      self.wfile.write(payload)
+    else:
+      self.send_response(404)
+      self.end_headers()
+
+  def log_message(self, format: str, *args) -> None:  # noqa: D401
+    pass
+
+
+@contextlib.contextmanager
+def run_server():
+  server = http.server.ThreadingHTTPServer(("localhost", 0), Handler)
+  thread = threading.Thread(target=server.serve_forever)
+  thread.daemon = True
+  thread.start()
+  try:
+    yield server
+  finally:
+    server.shutdown()
+    thread.join()
+
+
+def test_http_session_get():
+  with run_server() as srv:
+    port = srv.server_address[1]
+    with HttpSession(f"http://localhost:{port}") as sess:
+      with sess.get("/ping") as resp:
+        data = resp.read()
+        status = resp.status
+    assert status == 200
+    assert data == b"pong"
+
+
+def test_http_session_stream():
+  with run_server() as srv:
+    port = srv.server_address[1]
+    with HttpSession(f"http://localhost:{port}") as sess:
+      with sess.request("GET", "/ping") as resp:
+        chunks = list(resp.stream(2))
+        status = resp.status
+    assert b"".join(chunks) == b"pong"
+    assert status == 200
+
+
+def extract_next(resp: HttpResponse) -> str | None:
+  return json.loads(resp.read().decode())["next"]
+
+
+def test_http_session_paginate():
+  with run_server() as srv:
+    port = srv.server_address[1]
+    with HttpSession(f"http://localhost:{port}") as sess:
+      pages = list(sess.paginate("/p1", extract_next))
+    assert [json.loads(p.read())["data"] for p in pages] == [1, 2, 3]
+
+
+def test_http_session_paginate_no_cache():
+  with run_server() as srv:
+    port = srv.server_address[1]
+    with HttpSession(f"http://localhost:{port}") as sess:
+      pages = list(sess.paginate("/p1", extract_next, cache_body=False))
+    assert [json.loads(p.read())["data"] for p in pages] == [1, 2, 3]


### PR DESCRIPTION
## Summary
- control caching with new `cache_body` flag on `HttpSession.paginate`
- test optional caching behavior in pagination

## Testing
- `ruff format helpers/utils.py tests/helpers/test_http_session.py --check`
- `ruff check helpers/utils.py tests/helpers/test_http_session.py`
- `pytest -q -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_b_68461e6cc84c83288eb90b6c1ae17382